### PR TITLE
Update for v71 of the Platform SDK

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -13,8 +13,8 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: main
   SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
-  # Meta Platform SDK v67.0.
-  META_PLATFORM_SDK_URL: "https://securecdn.oculus.com/binaries/download/?id=6176126005844383"
+  # Meta Platform SDK v71.0.
+  META_PLATFORM_SDK_URL: "https://securecdn.oculus.com/binaries/download/?id=6945981485525494"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git submodule update --init --recursive
 Then download the [Oculus Platform SDK](https://developer.oculus.com/downloads/package/oculus-platform-sdk/) and extract
 it into `thirdparty/ovr_platform_sdk`, such that `thirdparty/ovr_platform_sdk/Include/OVR_Platform.h` exists.
 
-We've tested with v67 of the Platform SDK.
+We've tested with v71 of the Platform SDK.
 
 ### Build the toolkit
 

--- a/doc_classes/MetaPlatformSDK.xml
+++ b/doc_classes/MetaPlatformSDK.xml
@@ -1101,6 +1101,13 @@
 				Returns the currently logged-in user's locale as a string, or empty string on error. Return value format conforms to [url=https://tools.ietf.org/html/bcp47]BCP47[/url]. The return value is borrowed, and should not be freed
 			</description>
 		</method>
+		<method name="user_get_logged_in_user_managed_info_async">
+			<return type="MetaPlatformSDK_Request" />
+			<description>
+				Retrieve the currently signed in user's managed info. This call is not available offline.
+				NOTE: This will return data only if the logged in user is a managed Meta account (MMA).
+			</description>
+		</method>
 		<method name="user_get_next_blocked_user_array_page_async">
 			<return type="MetaPlatformSDK_Request" />
 			<param index="0" name="handle" type="MetaPlatformSDK_BlockedUserArray" />
@@ -1238,18 +1245,24 @@
 		<constant name="PARTY_UPDATE_ACTION_UNKNOWN" value="0" enum="PartyUpdateAction">
 		</constant>
 		<constant name="PARTY_UPDATE_ACTION_JOIN" value="1" enum="PartyUpdateAction">
+			Indicates the user joined the party.
 		</constant>
 		<constant name="PARTY_UPDATE_ACTION_LEAVE" value="2" enum="PartyUpdateAction">
+			Indicates the user left the party.
 		</constant>
 		<constant name="PARTY_UPDATE_ACTION_INVITE" value="3" enum="PartyUpdateAction">
+			Indicates the user was invited to the party.
 		</constant>
 		<constant name="PARTY_UPDATE_ACTION_UNINVITE" value="4" enum="PartyUpdateAction">
+			Indicates the user was uninvited to the party.
 		</constant>
 		<constant name="CHALLENGE_CREATION_TYPE_UNKNOWN" value="0" enum="ChallengeCreationType">
 		</constant>
 		<constant name="CHALLENGE_CREATION_TYPE_USER_CREATED" value="1" enum="ChallengeCreationType">
+			The challenge was created by a User. This means that a regular user of the app created the challenge, and it may be a community-driven challenge or a personal challenge created by the user for themselves or others.
 		</constant>
 		<constant name="CHALLENGE_CREATION_TYPE_DEVELOPER_CREATED" value="2" enum="ChallengeCreationType">
+			The challenge was created by the app developer. This means that the challenge was created by the team behind the app, and it may be an official challenge or a special event created by the developers to engage with the community or promote specific features of the app.
 		</constant>
 		<constant name="SERVICE_PROVIDER_UNKNOWN" value="0" enum="ServiceProvider">
 		</constant>
@@ -1269,11 +1282,24 @@
 		</constant>
 		<constant name="SHARE_MEDIA_STATUS_CANCELED" value="2" enum="ShareMediaStatus">
 		</constant>
+		<constant name="PRODUCT_TYPE_UNKNOWN" value="0" enum="ProductType">
+		</constant>
+		<constant name="PRODUCT_TYPE_DURABLE" value="1" enum="ProductType">
+			This product is a durable IAP item that can be consumed multiple times. It can be purchased only once.
+		</constant>
+		<constant name="PRODUCT_TYPE_CONSUMABLE" value="2" enum="ProductType">
+			This product is an IAP item that can be consumed only once. It can only be purchased again after it is consumed.
+		</constant>
+		<constant name="PRODUCT_TYPE_SUBSCRIPTION" value="3" enum="ProductType">
+			This product represents a subscription. Subscriptions provide a way for users to purchase your app or its premium content by way of a recurring payment model.
+		</constant>
 		<constant name="NET_SYNC_VOIP_STREAM_MODE_UNKNOWN" value="0" enum="NetSyncVoipStreamMode">
 		</constant>
 		<constant name="NET_SYNC_VOIP_STREAM_MODE_AMBISONIC" value="1" enum="NetSyncVoipStreamMode">
+			Represents the ambisonic steam mode the VoIP stream uses. It is the default value of [method MetaPlatformSDK_NetSyncOptions.set_voip_stream_default]. Since it allows for the creation of immersive, surround sound experiences that simulate real-world audio environments, it typically used in virtual reality (VR) and augmented reality (AR) applications.
 		</constant>
 		<constant name="NET_SYNC_VOIP_STREAM_MODE_MONO" value="2" enum="NetSyncVoipStreamMode">
+			Represents the mono steam mode the VoIP stream uses. The advantages mono stream mode has over ambisonic steam mode is the audio encoding and decoding require less computational resources and thus audio streams require less bandwidth. So it is typically used in applications with limited network resources.
 		</constant>
 		<constant name="TIME_WINDOW_UNKNOWN" value="0" enum="TimeWindow">
 		</constant>
@@ -1506,6 +1532,8 @@
 		</constant>
 		<constant name="MESSAGE_USER_GET_LOGGED_IN_USER_FRIENDS" value="1484532365" enum="MessageType">
 		</constant>
+		<constant name="MESSAGE_USER_GET_LOGGED_IN_USER_MANAGED_INFO" value="1891252974" enum="MessageType">
+		</constant>
 		<constant name="MESSAGE_USER_GET_NEXT_BLOCKED_USER_ARRAY_PAGE" value="2083192267" enum="MessageType">
 		</constant>
 		<constant name="MESSAGE_USER_GET_NEXT_USER_ARRAY_PAGE" value="645723971" enum="MessageType">
@@ -1618,12 +1646,15 @@
 			Response to the platform notification that the in-app reporting flow is unavailable or non-existent.
 		</constant>
 		<constant name="LEADERBOARD_FILTER_NONE" value="0" enum="LeaderboardFilterType">
+			No filter enabled on the leaderboard.
 		</constant>
 		<constant name="LEADERBOARD_FILTER_FRIENDS" value="1" enum="LeaderboardFilterType">
+			Indicates that the leaderboard should be filtered to include only friends (bidirectional followers) of the current user.
 		</constant>
 		<constant name="LEADERBOARD_FILTER_UNKNOWN" value="2" enum="LeaderboardFilterType">
 		</constant>
 		<constant name="LEADERBOARD_FILTER_USER_IDS" value="3" enum="LeaderboardFilterType">
+			Filter the leaderboard to include specific user IDs. Use this filter to get rankings for users that are competing against each other. You specify the leaderboard name and whether to start at the top, or for the results to center on the (client) user. Note that if you specify the results to center on the client user, their leaderboard entry will be included in the returned array, regardless of whether their ID is explicitly specified in the list of IDs.
 		</constant>
 		<constant name="VOIP_MUTE_STATE_UNKNOWN" value="0" enum="VoipMuteState">
 		</constant>
@@ -1640,16 +1671,21 @@
 			A report for a user's behavior or profile.
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_SUCCESS" value="1" enum="LivestreamingStartStatus">
+			Represents a successful start of the livestreaming session.
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_UNKNOWN" value="0" enum="LivestreamingStartStatus">
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_NO_PACKAGE_SET" value="-1" enum="LivestreamingStartStatus">
+			Represents an error where the package was not set during the livestreaming start process.
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_NO_FB_CONNECT" value="-2" enum="LivestreamingStartStatus">
+			Represents an error where Facebook Connect was not enabled during the livestreaming start process.
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_NO_SESSION_ID" value="-3" enum="LivestreamingStartStatus">
+			Represents an error where a session ID was not provided during the livestreaming start process.
 		</constant>
 		<constant name="LIVESTREAMING_START_STATUS_MISSING_PARAMETERS" value="-4" enum="LivestreamingStartStatus">
+			Represents an error where required parameters were missing during the livestreaming start process.
 		</constant>
 		<constant name="SDK_ACCOUNT_TYPE_UNKNOWN" value="0" enum="SdkAccountType">
 		</constant>
@@ -1660,22 +1696,31 @@
 		<constant name="LAUNCH_RESULT_UNKNOWN" value="0" enum="LaunchResult">
 		</constant>
 		<constant name="LAUNCH_RESULT_SUCCESS" value="1" enum="LaunchResult">
+			The application launched successfully.
 		</constant>
 		<constant name="LAUNCH_RESULT_FAILED_ROOM_FULL" value="2" enum="LaunchResult">
+			The application launch failed because the room was full.
 		</constant>
 		<constant name="LAUNCH_RESULT_FAILED_GAME_ALREADY_STARTED" value="3" enum="LaunchResult">
+			The application launch failed because the game has already started.
 		</constant>
 		<constant name="LAUNCH_RESULT_FAILED_ROOM_NOT_FOUND" value="4" enum="LaunchResult">
+			The appplicatin launch failed because the room couldn't be found.
 		</constant>
 		<constant name="LAUNCH_RESULT_FAILED_USER_DECLINED" value="5" enum="LaunchResult">
+			The application launch failed because the user declined the invitation.
 		</constant>
 		<constant name="LAUNCH_RESULT_FAILED_OTHER_REASON" value="6" enum="LaunchResult">
+			The application launch failed due to some other reason.
 		</constant>
 		<constant name="LEADERBOARD_START_AT_TOP" value="0" enum="LeaderboardStartAt">
+			Indicates that the leaderboard entries should start at the top of the leaderboard.
 		</constant>
 		<constant name="LEADERBOARD_START_AT_CENTERED_ON_VIEWER" value="1" enum="LeaderboardStartAt">
+			Indicates that the leaderboard entries should start at the viewer's position on the leaderboard
 		</constant>
 		<constant name="LEADERBOARD_START_AT_CENTERED_ON_VIEWER_OR_TOP" value="2" enum="LeaderboardStartAt">
+			Indicates that the leaderboard entries should start at the viewer's position on the leaderboard, or at the top of the leaderboard if the viewer is not present.
 		</constant>
 		<constant name="LEADERBOARD_START_AT_UNKNOWN" value="3" enum="LeaderboardStartAt">
 		</constant>
@@ -1703,32 +1748,44 @@
 			Install of the app succeeded.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_SUCCESS" value="0" enum="PlatformInitializeResult">
+			Oculus Platform SDK initialization succeeded.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_UNINITIALIZED" value="-1" enum="PlatformInitializeResult">
+			Oculus Platform SDK was not initialized.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_PRE_LOADED" value="-2" enum="PlatformInitializeResult">
+			Oculus Platform SDK failed to initialize because the pre-loaded module was on a different path than the validated library.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_FILE_INVALID" value="-3" enum="PlatformInitializeResult">
+			Oculus Platform SDK files failed to load.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_SIGNATURE_INVALID" value="-4" enum="PlatformInitializeResult">
+			Oculus Platform SDK failed to initialize due to an invalid signature in the signed certificate.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_UNABLE_TO_VERIFY" value="-5" enum="PlatformInitializeResult">
+			Oculus Platform SDK failed to initialize due to unable to verify the application's signature during initialization.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_VERSION_MISMATCH" value="-6" enum="PlatformInitializeResult">
+			There was a mismatch between the version of Oculus Platform SDK used by the application and the version installed on the Oculus user's device.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_UNKNOWN" value="-7" enum="PlatformInitializeResult">
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_INVALID_CREDENTIALS" value="-8" enum="PlatformInitializeResult">
+			Oculus Platform SDK failed to initialize because the Oculus user had an invalid account access token.
 		</constant>
 		<constant name="PLATFORM_INITIALIZE_NOT_ENTITLED" value="-9" enum="PlatformInitializeResult">
+			Oculus Platform SDK failed to initialize because the Oculus user does not have the application entitlement.
 		</constant>
 		<constant name="NET_SYNC_CONNECTION_STATUS_UNKNOWN" value="0" enum="NetSyncConnectionStatus">
 		</constant>
 		<constant name="NET_SYNC_CONNECTION_STATUS_CONNECTING" value="1" enum="NetSyncConnectionStatus">
+			Indicates that the connection of the network sync has been started and the process is ongoing.
 		</constant>
 		<constant name="NET_SYNC_CONNECTION_STATUS_DISCONNECTED" value="2" enum="NetSyncConnectionStatus">
+			Indicates that the current status of the network sync connection is not connected.
 		</constant>
 		<constant name="NET_SYNC_CONNECTION_STATUS_CONNECTED" value="3" enum="NetSyncConnectionStatus">
+			Indicates that the current status of the network sync connection is connected.
 		</constant>
 		<constant name="CHALLENGE_VISIBILITY_UNKNOWN" value="0" enum="ChallengeVisibility">
 		</constant>
@@ -1758,20 +1815,28 @@
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_UNKNOWN" value="0" enum="MultiplayerErrorErrorKey">
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_DESTINATION_UNAVAILABLE" value="1" enum="MultiplayerErrorErrorKey">
+			Indicates that the travel destination is not available any more.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_DLC_REQUIRED" value="2" enum="MultiplayerErrorErrorKey">
+			Indicates that the downloadable content will be needed.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_GENERAL" value="3" enum="MultiplayerErrorErrorKey">
+			Indicates a broad range of general errors which are not be covered by the members of the enum.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_GROUP_FULL" value="4" enum="MultiplayerErrorErrorKey">
+			Indicates that the user failed to join the group because it was full.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_INVITER_NOT_JOINABLE" value="5" enum="MultiplayerErrorErrorKey">
+			Indicates that the user cannot invite a recepient successfully. The group presence can be set to joinable by using [method group_presence_set_is_joinable_async].
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_LEVEL_NOT_HIGH_ENOUGH" value="6" enum="MultiplayerErrorErrorKey">
+			Indicates that certain features will not be available to the user in the app because the user's level does not reach to certain level.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_LEVEL_NOT_UNLOCKED" value="7" enum="MultiplayerErrorErrorKey">
+			Indicates that the failure occurred becasue some level has not been reached.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_NETWORK_TIMEOUT" value="8" enum="MultiplayerErrorErrorKey">
+			When the predefined network timeout has reached, the ongoing activity would be stopped. The dialog will use this error key to give the user the information.
 		</constant>
 		<constant name="MULTIPLAYER_ERROR_ERROR_KEY_NO_LONGER_AVAILABLE" value="9" enum="MultiplayerErrorErrorKey">
 		</constant>
@@ -1807,30 +1872,40 @@
 		<constant name="USER_PRESENCE_STATUS_UNKNOWN" value="0" enum="UserPresenceStatus">
 		</constant>
 		<constant name="USER_PRESENCE_STATUS_ONLINE" value="1" enum="UserPresenceStatus">
+			The user status is currently online.
 		</constant>
 		<constant name="USER_PRESENCE_STATUS_OFFLINE" value="2" enum="UserPresenceStatus">
+			The user status is currently offline.
 		</constant>
 		<constant name="MEDIA_CONTENT_TYPE_UNKNOWN" value="0" enum="MediaContentType">
 		</constant>
 		<constant name="MEDIA_CONTENT_TYPE_PHOTO" value="1" enum="MediaContentType">
+			Indicates that the media content is a photo.
 		</constant>
 		<constant name="CHALLENGE_VIEWER_FILTER_UNKNOWN" value="0" enum="ChallengeViewerFilter">
 		</constant>
 		<constant name="CHALLENGE_VIEWER_FILTER_ALL_VISIBLE" value="1" enum="ChallengeViewerFilter">
+			Returns all public and invite-only challenges in which the user is a participant or invitee. Excludes private challenges. This filter is useful for users who want to see all challenges they are involved in, regardless of their visibility settings.
 		</constant>
 		<constant name="CHALLENGE_VIEWER_FILTER_PARTICIPATING" value="2" enum="ChallengeViewerFilter">
+			Returns challenges in which the user is a participant. This filter is useful for users who want to see only the challenges they are actively participating in.
 		</constant>
 		<constant name="CHALLENGE_VIEWER_FILTER_INVITED" value="3" enum="ChallengeViewerFilter">
+			Returns challenges that the user has been invited to. This filter is useful for users who want to see only the challenges they have been explicitly invited to.
 		</constant>
 		<constant name="CHALLENGE_VIEWER_FILTER_PARTICIPATING_OR_INVITED" value="4" enum="ChallengeViewerFilter">
+			Returns challenges the user is either participating in or invited to. This filter is useful for users who want to see all challenges they are involved in, whether as a participant or an invitee.
 		</constant>
 		<constant name="ACHIEVEMENT_TYPE_UNKNOWN" value="0" enum="AchievementType">
 		</constant>
 		<constant name="ACHIEVEMENT_TYPE_SIMPLE" value="1" enum="AchievementType">
+			Simple achievements are unlocked by a single event or objective completion. They are often used to reward players for completing specific tasks or milestones within the game.
 		</constant>
 		<constant name="ACHIEVEMENT_TYPE_BITFIELD" value="2" enum="AchievementType">
+			Bitfield achievements are unlocked when a target number of bits are set within a bitfield.
 		</constant>
 		<constant name="ACHIEVEMENT_TYPE_COUNT" value="3" enum="AchievementType">
+			Count achievements are unlocked when a counter reaches a defined target. The counter is incremented each time the player completes the required action, and when it reaches the target value, the achievement is unlocked.
 		</constant>
 		<constant name="SYSTEM_VOIP_STATUS_UNKNOWN" value="0" enum="SystemVoipStatus">
 		</constant>

--- a/doc_classes/MetaPlatformSDK_AchievementUpdate.xml
+++ b/doc_classes/MetaPlatformSDK_AchievementUpdate.xml
@@ -10,8 +10,10 @@
 	</tutorials>
 	<members>
 		<member name="just_unlocked" type="bool" setter="" getter="get_just_unlocked" default="false">
+			This indicates if this update caused the achievement to unlock.
 		</member>
 		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The unique name used to reference the updated achievement, as specified in the developer dashboard.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_ApplicationInvite.xml
+++ b/doc_classes/MetaPlatformSDK_ApplicationInvite.xml
@@ -13,12 +13,16 @@
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The ID of the application invite.
 		</member>
 		<member name="is_active" type="bool" setter="" getter="get_is_active" default="false">
+			A boolean value indicating whether the invite is still active or not.
 		</member>
 		<member name="lobby_session_id" type="String" setter="" getter="get_lobby_session_id" default="&quot;&quot;">
+			The lobby session id to which the recipient is invited.
 		</member>
 		<member name="match_session_id" type="String" setter="" getter="get_match_session_id" default="&quot;&quot;">
+			The match session id to which the recipient is invited.
 		</member>
 		<member name="recipient" type="MetaPlatformSDK_User" setter="" getter="get_recipient">
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.

--- a/doc_classes/MetaPlatformSDK_Challenge.xml
+++ b/doc_classes/MetaPlatformSDK_Challenge.xml
@@ -16,8 +16,10 @@
 			A displayable string of the challenge's description.
 		</member>
 		<member name="end_date" type="int" setter="" getter="get_end_date" default="0">
+			The timestamp when this challenge ends. You can retrieve this field from the response of the challenge creation request.
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The ID of the challenge. This is an unique string that the application will refer to this challenge in your app.
 		</member>
 		<member name="invited_users" type="MetaPlatformSDK_UserArray" setter="" getter="get_invited_users">
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.
@@ -29,6 +31,7 @@
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.
 		</member>
 		<member name="start_date" type="int" setter="" getter="get_start_date" default="0">
+			The timestamp when this challenge begins. You can retrieve this field from the response of the challenge creation request.
 		</member>
 		<member name="title" type="String" setter="" getter="get_title" default="&quot;&quot;">
 			A displayable string of the challenge's title.

--- a/doc_classes/MetaPlatformSDK_ChallengeEntry.xml
+++ b/doc_classes/MetaPlatformSDK_ChallengeEntry.xml
@@ -10,20 +10,27 @@
 	</tutorials>
 	<members>
 		<member name="display_score" type="String" setter="" getter="get_display_score" default="&quot;&quot;">
+			A displayable score for this challenge entry. The score is formatted with thousands separators and the relevant units are appended based on the associated leaderboard's score type.
 		</member>
 		<member name="extra_data" type="String" setter="" getter="get_extra_data" default="&quot;&quot;">
+			A 2KB custom data field that is associated with the challenge entry.
 		</member>
 		<member name="extra_data_length" type="int" setter="" getter="get_extra_data_length" default="0">
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The unique identifier of this challenge entry which can be used by [method MetaPlatformSDK.challenges_get_entries_by_ids_async] and [method MetaPlatformSDK.challenges_get_entries_async].
 		</member>
 		<member name="rank" type="int" setter="" getter="get_rank" default="0">
+			Challenges can be ranked by highest or lowest scores within a time period. This indicates the position of this challenge entry.
 		</member>
 		<member name="score" type="int" setter="" getter="get_score" default="0">
+			The raw underlying value of the challenge entry score. It is a type of string that is returned by a long integer.
 		</member>
 		<member name="timestamp" type="int" setter="" getter="get_timestamp" default="0">
+			The timestamp of the creation of this entry in the challenge.
 		</member>
 		<member name="user" type="MetaPlatformSDK_User" setter="" getter="get_user">
+			The user corresponding to this entry within the challenge.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_ChallengeOptions.xml
+++ b/doc_classes/MetaPlatformSDK_ChallengeOptions.xml
@@ -13,30 +13,35 @@
 			<return type="void" />
 			<param index="0" name="value" type="String" />
 			<description>
+				The description of the challenge is a detailed and informative text that provides a comprehensive overview of the challenge's objectives, rules, and requirements.
 			</description>
 		</method>
 		<method name="set_end_date">
 			<return type="void" />
 			<param index="0" name="value" type="int" />
 			<description>
+				The challenge end date is the timestamp when this challenge ends.
 			</description>
 		</method>
 		<method name="set_include_active_challenges">
 			<return type="void" />
 			<param index="0" name="value" type="bool" />
 			<description>
+				This option indicates whether to include challenges that are currently active in the search results. By default, this is set to true, meaning that only active challenges will be returned.
 			</description>
 		</method>
 		<method name="set_include_future_challenges">
 			<return type="void" />
 			<param index="0" name="value" type="bool" />
 			<description>
+				This option indicates whether to include challenges that have not yet started in the search results. By default, this is set to false, meaning that only active will be returned.
 			</description>
 		</method>
 		<method name="set_include_past_challenges">
 			<return type="void" />
 			<param index="0" name="value" type="bool" />
 			<description>
+				This option indicates whether to include challenges that have already ended in the search results. By default, this is set to false, meaning that only active will be returned.
 			</description>
 		</method>
 		<method name="set_leaderboard_name">
@@ -50,24 +55,29 @@
 			<return type="void" />
 			<param index="0" name="value" type="int" />
 			<description>
+				The challenge start date is the timestamp when this challenge begins.
 			</description>
 		</method>
 		<method name="set_title">
 			<return type="void" />
 			<param index="0" name="value" type="String" />
 			<description>
+				The title of the challenge is a descriptive label that provides a concise summary of the challenge's purpose and objectives.
 			</description>
 		</method>
 		<method name="set_viewer_filter">
 			<return type="void" />
 			<param index="0" name="value" type="int" enum="MetaPlatformSDK.ChallengeViewerFilter" />
 			<description>
+				An enum that specifies what filter to apply to the list of returned challenges.
+				Returns all public and invite-only challenges in which the user is a participant or invitee. Excludes private challenges.
 			</description>
 		</method>
 		<method name="set_visibility">
 			<return type="void" />
 			<param index="0" name="value" type="int" enum="MetaPlatformSDK.ChallengeVisibility" />
 			<description>
+				The challenge visibility setting specifies who can see and participate in this challenge.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/MetaPlatformSDK_DataStore.xml
+++ b/doc_classes/MetaPlatformSDK_DataStore.xml
@@ -13,23 +13,27 @@
 			<return type="int" />
 			<param index="0" name="key" type="String" />
 			<description>
+				It's a method that takes a string key as a parameter and returns a boolean value indicating whether the key exists in the data store.
 			</description>
 		</method>
 		<method name="get_key" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
+				It's a string that represents a single key in the data store. It allows you to retrieve a specific key from the data store by its index
 			</description>
 		</method>
 		<method name="get_value" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="key" type="String" />
 			<description>
+				It's a generic field that can hold any type of data. It allows you to store and retrieve data using a string key, and it can be used to store a variety of data types
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="num_keys" type="int" setter="" getter="get_num_keys" default="0">
+			It's an integer that represents the number of keys in the data store.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_Destination.xml
+++ b/doc_classes/MetaPlatformSDK_Destination.xml
@@ -16,6 +16,7 @@
 			The information that will be in [member MetaPlatformSDK_LaunchDetails.deeplink_message] when a user enters via deeplink. Alternatively will be in [member MetaPlatformSDK_User.presence_deeplink_message] if the rich presence is set for the user.
 		</member>
 		<member name="display_name" type="String" setter="" getter="get_display_name" default="&quot;&quot;">
+			A displayable string of the destination name.
 		</member>
 		<member name="shareable_uri" type="String" setter="" getter="get_shareable_uri" default="&quot;&quot;">
 			A URL that allows the user to deeplink directly to this destination.

--- a/doc_classes/MetaPlatformSDK_Error.xml
+++ b/doc_classes/MetaPlatformSDK_Error.xml
@@ -11,11 +11,20 @@
 	</tutorials>
 	<members>
 		<member name="code" type="int" setter="" getter="get_code" default="0">
+			Represents the error code:
+			- [code]UNKNOWN_ERROR[/code]: [code]1[/code]
+			- [code]AUTHENTICATION_ERROR[/code]: [code]2[/code]
+			- [code]NETWORK_ERROR[/code]: [code]3[/code]
+			- [code]STORE_INSTALLATION_ERROR[/code]: [code]4[/code]
+			- [code]CALLER_NOT_SIGNED[/code]: [code]5[/code]
+			- [code]UNKNOWN_SERVER_ERROR[/code]: [code]6[/code]
+			- [code]PERMISSIONS_FAILURE[/code]: [code]7[/code]
 		</member>
 		<member name="displayable_message" type="String" setter="" getter="get_displayable_message" default="&quot;&quot;">
 			Human readable description of the error that can be displayed to the user. Might be the empty string if there is no user-appropriate description available. Not intended to be parsed as it might change at any time or be translated.
 		</member>
 		<member name="http_code" type="int" setter="" getter="get_http_code" default="0">
+			It contains the HTTP status code for the error. More information about the http code can be found [url=https://en.wikipedia.org/wiki/List_of_HTTP_status_codes]here[/url].
 		</member>
 		<member name="message" type="String" setter="" getter="get_message" default="&quot;&quot;">
 			Technical description of what went wrong intended for developers. For use in logs or developer consoles.

--- a/doc_classes/MetaPlatformSDK_HttpTransferUpdate.xml
+++ b/doc_classes/MetaPlatformSDK_HttpTransferUpdate.xml
@@ -12,11 +12,13 @@
 		<method name="is_completed" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Indicates whether the HTTP transfer has been completed or not.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="bytes" type="PackedByteArray" setter="" getter="get_bytes" default="PackedByteArray()">
+			An array of bytes that represents the data being transferred.
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
 		</member>

--- a/doc_classes/MetaPlatformSDK_InstalledApplication.xml
+++ b/doc_classes/MetaPlatformSDK_InstalledApplication.xml
@@ -10,14 +10,19 @@
 	</tutorials>
 	<members>
 		<member name="application_id" type="String" setter="" getter="get_application_id" default="&quot;&quot;">
+			Represents the ID of the application, which is a unique identifier for the app.
 		</member>
 		<member name="package_name" type="String" setter="" getter="get_package_name" default="&quot;&quot;">
+			The package name of the installed application.
 		</member>
 		<member name="status" type="String" setter="" getter="get_status" default="&quot;&quot;">
+			Represents the status of the installed application.
 		</member>
 		<member name="version_code" type="int" setter="" getter="get_version_code" default="0">
+			Represents the current version code of the installed application.
 		</member>
 		<member name="version_name" type="String" setter="" getter="get_version_name" default="&quot;&quot;">
+			Represents the current version name of the installed application.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LaunchDetails.xml
+++ b/doc_classes/MetaPlatformSDK_LaunchDetails.xml
@@ -19,6 +19,7 @@
 			A string typically used to distinguish where the deeplink came from. For instance, a DEEPLINK launch type could be coming from events or rich presence.
 		</member>
 		<member name="launch_type" type="int" setter="" getter="get_launch_type" enum="MetaPlatformSDK.LaunchType" default="0">
+			A launch type that defines the different ways in which an application can be launched.
 		</member>
 		<member name="lobby_session_id" type="String" setter="" getter="get_lobby_session_id" default="&quot;&quot;">
 			If provided, the intended lobby the user would like to be in.

--- a/doc_classes/MetaPlatformSDK_Leaderboard.xml
+++ b/doc_classes/MetaPlatformSDK_Leaderboard.xml
@@ -10,11 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="api_name" type="String" setter="" getter="get_api_name" default="&quot;&quot;">
+			The API name of this leaderboard. This is a unique string that your application will refer to this leaderboard in your app code.
 		</member>
 		<member name="destination" type="MetaPlatformSDK_Destination" setter="" getter="get_destination">
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The generated GUID of this leaderboard.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LeaderboardArray.xml
+++ b/doc_classes/MetaPlatformSDK_LeaderboardArray.xml
@@ -14,21 +14,25 @@
 			<return type="MetaPlatformSDK_Leaderboard" />
 			<param index="0" name="index" type="int" />
 			<description>
+				Access the indexed element in this list. Note that the index is zero-based, so the first element has an index of 0.
 			</description>
 		</method>
 		<method name="has_next_page" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Indicates whether there is a next page of elements that can be retrieved. If this value is true, you can use the next_url field to request the next page of elements.
 			</description>
 		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
+				The number of elements contained within this list. This is not equal to the total number of elements across multiple pages.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="next_url" type="String" setter="" getter="get_next_url" default="&quot;&quot;">
+			The URL to request the next paginated list of elements.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LeaderboardEntry.xml
+++ b/doc_classes/MetaPlatformSDK_LeaderboardEntry.xml
@@ -10,23 +10,30 @@
 	</tutorials>
 	<members>
 		<member name="display_score" type="String" setter="" getter="get_display_score" default="&quot;&quot;">
+			The formatted score that will be displayed in the leaderboard of this entry. You can select a score type to determine how scores are displayed on Leaderboard. See [url=https://developer.oculus.com/documentation/native/ps-leaderboards/#create]here[/url] for examples of different score type.
 		</member>
 		<member name="extra_data" type="String" setter="" getter="get_extra_data" default="&quot;&quot;">
+			A 2KB custom data field that is associated with the leaderboard entry. This can be a game replay or anything that provides more detail about the entry to the viewer. It will be used by two entry methods: [method MetaPlatformSDK.leaderboard_write_entry_async] and [method MetaPlatformSDK.leaderboard_write_entry_with_supplementary_metric_async].
 		</member>
 		<member name="extra_data_length" type="int" setter="" getter="get_extra_data_length" default="0">
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			This is a unique identifier for the leaderboard entry. It is of type `id` and is optional.
 		</member>
 		<member name="rank" type="int" setter="" getter="get_rank" default="0">
+			The rank of this leaderboard entry in the leaderboard. It can be used in [method MetaPlatformSDK.leaderboard_get_entries_after_rank_async] to retrieve leaderboard entries starting from a specified rank.
 		</member>
 		<member name="score" type="int" setter="" getter="get_score" default="0">
+			The raw underlying value of the score achieved by the user in the leaderboard. It's of type `long_as_string` and it's used to determine the user's rank in the leaderboard.
 		</member>
 		<member name="supplementary_metric" type="MetaPlatformSDK_SupplementaryMetric" setter="" getter="get_supplementary_metric">
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.
 		</member>
 		<member name="timestamp" type="int" setter="" getter="get_timestamp" default="0">
+			The timestamp of this entry being created in the leaderboard.
 		</member>
 		<member name="user" type="MetaPlatformSDK_User" setter="" getter="get_user">
+			User of this leaderboard entry. You can request a block of leaderboard entries for the specified user ID(s) by [method MetaPlatformSDK.leaderboard_get_entries_by_ids_async].
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LeaderboardUpdateStatus.xml
+++ b/doc_classes/MetaPlatformSDK_LeaderboardUpdateStatus.xml
@@ -13,11 +13,13 @@
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
+				If the leaderboard is updated, this represents the updated challenge IDs. The updated challenge IDs can be used by [method MetaPlatformSDK.challenges_get_entries_async], [method MetaPlatformSDK.challenges_get_entries_after_rank_async] or [method MetaPlatformSDK.challenges_get_entries_by_ids_async].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="did_update" type="bool" setter="" getter="get_did_update" default="false">
+			A `boolean` indicates whether the leaderboard was updated.
 		</member>
 		<member name="updated_challenge_ids_size" type="int" setter="" getter="get_updated_challenge_ids_size" default="0">
 		</member>

--- a/doc_classes/MetaPlatformSDK_LivestreamingApplicationStatus.xml
+++ b/doc_classes/MetaPlatformSDK_LivestreamingApplicationStatus.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="streaming_enabled" type="bool" setter="" getter="get_streaming_enabled" default="false">
+			This is a boolean field and represents whether the app is allowed to do the livestreaming or not.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LivestreamingStartResult.xml
+++ b/doc_classes/MetaPlatformSDK_LivestreamingStartResult.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="streaming_result" type="int" setter="" getter="get_streaming_result" enum="MetaPlatformSDK.LivestreamingStartStatus" default="1">
+			This livestreaming result represents the start status of your livestream.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LivestreamingStatus.xml
+++ b/doc_classes/MetaPlatformSDK_LivestreamingStatus.xml
@@ -10,14 +10,19 @@
 	</tutorials>
 	<members>
 		<member name="comments_visible" type="bool" setter="" getter="get_comments_visible" default="false">
+			Indicates if the comments from the audience in your livestreaming are visible.
 		</member>
 		<member name="is_paused" type="bool" setter="" getter="get_is_paused" default="false">
+			Indicates if your livestreaming in the app is paused or not.
 		</member>
 		<member name="livestreaming_enabled" type="bool" setter="" getter="get_livestreaming_enabled" default="false">
+			Indicates if your app is livestreaming enabled. If your app is enabled, you will receive a notification by #ovrMessage_Notification_Livestreaming_StatusChange when the livestreaming session gets updated.
 		</member>
 		<member name="livestreaming_type" type="int" setter="" getter="get_livestreaming_type" default="0">
+			Indicates the type of your livestreaming.
 		</member>
 		<member name="mic_enabled" type="bool" setter="" getter="get_mic_enabled" default="false">
+			Indicates if your connected mic is enabled. The speaker will be muted if the field is false.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_LivestreamingVideoStats.xml
+++ b/doc_classes/MetaPlatformSDK_LivestreamingVideoStats.xml
@@ -10,10 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="comment_count" type="int" setter="" getter="get_comment_count" default="0">
+			The total number of comments left for your livestream video.
 		</member>
 		<member name="reaction_count" type="int" setter="" getter="get_reaction_count" default="0">
+			The total number of reactions your livestream video received.
 		</member>
 		<member name="total_views" type="String" setter="" getter="get_total_views" default="&quot;&quot;">
+			The total number of views of your livestream video.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_ManagedInfo.xml
+++ b/doc_classes/MetaPlatformSDK_ManagedInfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MetaPlatformSDK_ManagedInfo" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Represents information about a user with a managed device.
+	</brief_description>
+	<description>
+		Represents information about a user with a managed device.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="department" type="String" setter="" getter="get_department" default="&quot;&quot;">
+			The department name in the organization to which the user blongs to.
+		</member>
+		<member name="email" type="String" setter="" getter="get_email" default="&quot;&quot;">
+			The email address of the account user which owns the MMA (Meta Managed Account).
+		</member>
+		<member name="employee_number" type="String" setter="" getter="get_employee_number" default="&quot;&quot;">
+			The employee number of the person who owns MMA (Meta Managed Account).
+		</member>
+		<member name="external_id" type="String" setter="" getter="get_external_id" default="&quot;&quot;">
+			A string which can be used to uniquely identify the user of the MMA (Meta Managed Account).
+		</member>
+		<member name="location" type="String" setter="" getter="get_location" default="&quot;&quot;">
+			The location of the user.
+		</member>
+		<member name="manager" type="String" setter="" getter="get_manager" default="&quot;&quot;">
+			The manager of the user.
+		</member>
+		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The user's name.
+		</member>
+		<member name="organization_id" type="String" setter="" getter="get_organization_id" default="&quot;&quot;">
+			A string which can be used to uniquely identify the organization which owns the MMA (Meta Managed Account).
+		</member>
+		<member name="organization_name" type="String" setter="" getter="get_organization_name" default="&quot;&quot;">
+			The name of the organization to which the MMA (Meta Managed Account) account user belongs to.
+		</member>
+		<member name="position" type="String" setter="" getter="get_position" default="&quot;&quot;">
+			The user's position.
+		</member>
+	</members>
+</class>

--- a/doc_classes/MetaPlatformSDK_MicrophoneAvailabilityState.xml
+++ b/doc_classes/MetaPlatformSDK_MicrophoneAvailabilityState.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="microphone_available" type="bool" setter="" getter="get_microphone_available" default="false">
+			Indicates whether the microphone is currently available or not. If there is any update on the microphone availability, it will be retrieved as a notification using [constant MetaPlatformSDK.MESSAGE_NOTIFICATION_VOIP_MICROPHONE_AVAILABILITY_STATE_UPDATE].
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_NetSyncConnection.xml
+++ b/doc_classes/MetaPlatformSDK_NetSyncConnection.xml
@@ -10,16 +10,19 @@
 	</tutorials>
 	<members>
 		<member name="connection_id" type="int" setter="" getter="get_connection_id" default="0">
+			An ID which can be used to uniquely identify the network synchronization connection.
 		</member>
 		<member name="disconnect_reason" type="int" setter="" getter="get_disconnect_reason" enum="MetaPlatformSDK.NetSyncDisconnectReason" default="0">
-			If status is Disconnected, specifies the reason.
+			If status is disconnected, specifies the reason.
 		</member>
 		<member name="session_id" type="int" setter="" getter="get_session_id" default="0">
-			The ID of the local session. Will be null if the connection is not active.
+			The ID of the local session. Will be [code]null[/code] if the connection is not active.
 		</member>
 		<member name="status" type="int" setter="" getter="get_status" enum="MetaPlatformSDK.NetSyncConnectionStatus" default="0">
+			The status of the network synchronization connection.
 		</member>
 		<member name="zone_id" type="String" setter="" getter="get_zone_id" default="&quot;&quot;">
+			Represents the unique identifier within the current application grouping.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_NetSyncSessionsChangedNotification.xml
+++ b/doc_classes/MetaPlatformSDK_NetSyncSessionsChangedNotification.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="connection_id" type="int" setter="" getter="get_connection_id" default="0">
+			An ID which can be used to uniquely identify the network synchronization connection.
 		</member>
 		<member name="sessions" type="MetaPlatformSDK_NetSyncSessionArray" setter="" getter="get_sessions">
 			The new list of sessions.

--- a/doc_classes/MetaPlatformSDK_Packet.xml
+++ b/doc_classes/MetaPlatformSDK_Packet.xml
@@ -10,10 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="bytes" type="PackedByteArray" setter="" getter="get_bytes" default="PackedByteArray()">
+			The packet data. Ideally, it is recommended to keep a message under 1200 bytes so that data can fit into a single packet.
 		</member>
 		<member name="sender_id" type="int" setter="" getter="get_sender_id" default="0">
+			Represents the id of the sender of the packet.
 		</member>
 		<member name="size" type="int" setter="" getter="get_size" default="0">
+			The number of bytes in the packet.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_Party.xml
+++ b/doc_classes/MetaPlatformSDK_Party.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			A unique identifier of this party.
 		</member>
 		<member name="invited_users" type="MetaPlatformSDK_UserArray" setter="" getter="get_invited_users">
 			This may be [code]null[/code], which indicates that the value is not present or that the curent app or user is not permitted to access it.

--- a/doc_classes/MetaPlatformSDK_PartyID.xml
+++ b/doc_classes/MetaPlatformSDK_PartyID.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The party ID can be used to retrieve a [MetaPlatformSDK_Party]. Every party will have a unique ID that is associated with it.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_PartyUpdateNotification.xml
+++ b/doc_classes/MetaPlatformSDK_PartyUpdateNotification.xml
@@ -10,18 +10,25 @@
 	</tutorials>
 	<members>
 		<member name="action" type="int" setter="" getter="get_action" enum="MetaPlatformSDK.PartyUpdateAction" default="0">
+			The type of action related to the party and user that this notification holds.
 		</member>
 		<member name="party_id" type="int" setter="" getter="get_party_id" default="0">
+			The ID of the party that will be updated.
 		</member>
 		<member name="sender_id" type="int" setter="" getter="get_sender_id" default="0">
+			The id of the [MetaPlatformSDK_User] who initiated the action that this party update status notification is in reference to.
 		</member>
 		<member name="update_timestamp" type="String" setter="" getter="get_update_timestamp" default="&quot;&quot;">
+			A timestamp denoting when the party action occurred that this status update notification refers to.
 		</member>
 		<member name="user_alias" type="String" setter="" getter="get_user_alias" default="&quot;&quot;">
+			The alias of the [MetaPlatformSDK_User] whose party status has changed. This is an alias that is set by the user.
 		</member>
 		<member name="user_id" type="int" setter="" getter="get_user_id" default="0">
+			The ID of the user, whose party status has changed.
 		</member>
 		<member name="user_name" type="String" setter="" getter="get_user_name" default="&quot;&quot;">
+			The displayable name of the [MetaPlatformSDK_User] whose party status has changed.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_Pid.xml
+++ b/doc_classes/MetaPlatformSDK_Pid.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="id" type="String" setter="" getter="get_id" default="&quot;&quot;">
+			Unique identifier assigned to each process running in a system, used for tracking and managing purposes.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_PlatformInitialize.xml
+++ b/doc_classes/MetaPlatformSDK_PlatformInitialize.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="result" type="int" setter="" getter="get_result" enum="MetaPlatformSDK.PlatformInitializeResult" default="0">
+			The result of attempting to initialize the platform.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_Price.xml
+++ b/doc_classes/MetaPlatformSDK_Price.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MetaPlatformSDK_Price" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Represents a price.
+	</brief_description>
+	<description>
+		Represents a price.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="amount_in_hundredths" type="int" setter="" getter="get_amount_in_hundredths" default="0">
+			The price of the product in hundredths of currency units.
+		</member>
+		<member name="currency" type="String" setter="" getter="get_currency" default="&quot;&quot;">
+			The ISO 4217 currency code for the price of the product. For example, "USD", "GBP", "JPY".
+		</member>
+		<member name="formatted" type="String" setter="" getter="get_formatted" default="&quot;&quot;">
+			The formatted string representation of the price, e.g., "$0.78". The value depends on the [member currency] and [member amount_in_hundredths].
+		</member>
+	</members>
+</class>

--- a/doc_classes/MetaPlatformSDK_Product.xml
+++ b/doc_classes/MetaPlatformSDK_Product.xml
@@ -10,12 +10,22 @@
 	</tutorials>
 	<members>
 		<member name="description" type="String" setter="" getter="get_description" default="&quot;&quot;">
+			The description for the product. The description should be meaningful and explanatory to help outline the product and its features.
 		</member>
 		<member name="formatted_price" type="String" setter="" getter="get_formatted_price" default="&quot;&quot;">
+			The formatted string for the [MetaPlatformSDK_Price].
 		</member>
 		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The name of the product. This will be used as a the display name and should be aligned with the user facing title.
+		</member>
+		<member name="price" type="MetaPlatformSDK_Price" setter="" getter="get_price">
+			The [MetaPlatformSDK_Price] of the product contains the currency code, the amount in hundredths, and the formatted string representation.
 		</member>
 		<member name="sku" type="String" setter="" getter="get_sku" default="&quot;&quot;">
+			The unique string that you use to reference the product in your app. The SKU is case-sensitive and should match the SKU reference in your code.
+		</member>
+		<member name="type" type="int" setter="" getter="get_type" enum="MetaPlatformSDK.ProductType" default="0">
+			The type of product.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_Purchase.xml
+++ b/doc_classes/MetaPlatformSDK_Purchase.xml
@@ -10,16 +10,21 @@
 	</tutorials>
 	<members>
 		<member name="developer_payload" type="String" setter="" getter="get_developer_payload" default="&quot;&quot;">
+			The developer payload feature is unimplemented.
 		</member>
 		<member name="expiration_time" type="int" setter="" getter="get_expiration_time" default="0">
+			The time when the purchased [MetaPlatformSDK_Product] expires. This value only applies to subscriptions, and will be null for durable and consumable IAP items.
 		</member>
 		<member name="grant_time" type="int" setter="" getter="get_grant_time" default="0">
+			The timestamp that represents when the user was granted entitlement to the [MetaPlatformSDK_Product] that was purchased.
 		</member>
 		<member name="purchase_str_id" type="String" setter="" getter="get_purchase_str_id" default="&quot;&quot;">
 		</member>
 		<member name="reporting_id" type="String" setter="" getter="get_reporting_id" default="&quot;&quot;">
+			The Reporting ID feature is not implemented.
 		</member>
 		<member name="sku" type="String" setter="" getter="get_sku" default="&quot;&quot;">
+			The SKU of the IAP [MetaPlatformSDK_Product] that was purchased. This value is case-sensitive. To retrieve the product information, you can use this value when calling [method MetaPlatformSDK.iap_get_products_by_sku_async].
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_SdkAccount.xml
+++ b/doc_classes/MetaPlatformSDK_SdkAccount.xml
@@ -10,8 +10,10 @@
 	</tutorials>
 	<members>
 		<member name="account_type" type="int" setter="" getter="get_account_type" enum="MetaPlatformSDK.SdkAccountType" default="0">
+			The specific type of account that this sdk account represents.
 		</member>
 		<member name="user_id" type="int" setter="" getter="get_user_id" default="0">
+			The ID of the user of the sdk account. This is a unique value for every [MetaPlatformSDK_User].
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_ShareMediaResult.xml
+++ b/doc_classes/MetaPlatformSDK_ShareMediaResult.xml
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="status" type="int" setter="" getter="get_status" enum="MetaPlatformSDK.ShareMediaStatus" default="0">
+			The status of the share media result.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_SupplementaryMetric.xml
+++ b/doc_classes/MetaPlatformSDK_SupplementaryMetric.xml
@@ -10,8 +10,10 @@
 	</tutorials>
 	<members>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The ID of the leaderboard that this supplementary metric belongs to.
 		</member>
 		<member name="metric" type="int" setter="" getter="get_metric" default="0">
+			This is the metric that is used to determine tiebreaks.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_SystemVoipState.xml
+++ b/doc_classes/MetaPlatformSDK_SystemVoipState.xml
@@ -10,8 +10,10 @@
 	</tutorials>
 	<members>
 		<member name="microphone_muted" type="int" setter="" getter="get_microphone_muted" enum="MetaPlatformSDK.VoipMuteState" default="0">
+			A flag that is used to indicate the current state of the microphone.
 		</member>
 		<member name="status" type="int" setter="" getter="get_status" enum="MetaPlatformSDK.SystemVoipStatus" default="0">
+			The status enum that indicates the current state of the system VoIP.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_User.xml
+++ b/doc_classes/MetaPlatformSDK_User.xml
@@ -10,13 +10,19 @@
 	</tutorials>
 	<members>
 		<member name="display_name" type="String" setter="" getter="get_display_name" default="&quot;&quot;">
-			A potentially non unique displayable name chosen by the user. Could also be the same as the oculus_ID
+			A potentially non unique displayable name chosen by the user. Could also be the same as the [member oculus_id].
 		</member>
 		<member name="id" type="int" setter="" getter="get_id" default="0">
+			The ID of the user. This is a unique value for every individual user.
 		</member>
 		<member name="image_url" type="String" setter="" getter="get_image_url" default="&quot;&quot;">
+			The url of the profile picture that is chosen by the user.
+		</member>
+		<member name="managed_info" type="MetaPlatformSDK_ManagedInfo" setter="" getter="get_managed_info">
+			Managed account info for the user which contains further metadata that is only available if the user is a Meta Managed Account(MMA). There must be user consent via dialog during installation, your app must have DUC enabled, and the app must be admin-approved. This method may return null. This indicates that the value is not present or that the curent app or user is not permitted to access it.
 		</member>
 		<member name="oculus_id" type="String" setter="" getter="get_oculus_id" default="&quot;&quot;">
+			The oculus ID of the user. This is used across the developer dashboard and is unique to oculus.
 		</member>
 		<member name="presence" type="String" setter="" getter="get_presence" default="&quot;&quot;">
 			Human readable string of what the user is currently doing. Not intended to be parsed as it might change at anytime or be translated.
@@ -37,6 +43,7 @@
 			Enum value of what the user is currently doing.
 		</member>
 		<member name="small_image_url" type="String" setter="" getter="get_small_image_url" default="&quot;&quot;">
+			The url of the smaller/secondary profile picture that is chosen by the user.
 		</member>
 	</members>
 </class>

--- a/doc_classes/MetaPlatformSDK_UserOptions.xml
+++ b/doc_classes/MetaPlatformSDK_UserOptions.xml
@@ -13,23 +13,27 @@
 			<return type="void" />
 			<param index="0" name="value" type="int" enum="MetaPlatformSDK.ServiceProvider" />
 			<description>
+				Specifies a service provider for which linked accounts should be retrieved. Can be called multiple times to specify multiple service providers.
 			</description>
 		</method>
 		<method name="clear_service_providers">
 			<return type="void" />
 			<description>
+				Clears the list of services providers that was created by calling [method add_service_provider].
 			</description>
 		</method>
 		<method name="set_max_users">
 			<return type="void" />
 			<param index="0" name="value" type="int" />
 			<description>
+				This field specifies the maximum number of users that should be returned in the response.
 			</description>
 		</method>
 		<method name="set_time_window">
 			<return type="void" />
 			<param index="0" name="value" type="int" enum="MetaPlatformSDK.TimeWindow" />
 			<description>
+				This field specifies the time window in seconds for which the linked accounts should be retrieved.
 			</description>
 		</method>
 	</methods>

--- a/generate_platform_sdk_bindings.py
+++ b/generate_platform_sdk_bindings.py
@@ -1688,6 +1688,7 @@ def update_docs_xml(plan, docs_path, overwrite_docs=False):
             xml_data = re.sub(r'^<class (xmlns:xsi="[^"]*" )(.*) xsi:', r'<class \2 \1xsi:', xml_data, flags=re.MULTILINE)
             xml_data = re.sub(r'(\S)/>', r'\1 />', xml_data)
             xml_data = re.sub(r'>([^<]+)<', lambda m: '>'+m.group(1).replace('&quot;', '"')+'<', xml_data)
+            xml_data += "\n"
 
             with open(xml_path, 'wt') as fd:
                 fd.write(xml_data)


### PR DESCRIPTION
This updates to v71 of the Meta Platform SDK, which is (at the moment) the latest version.

All of the code auto-generation seems to have worked correctly, and the new APIs are available!

The documentation generation was a little more hit or miss, and I had to rewrite a bunch of the new docs that got pulled in from the headers.