### PR TITLE
Fix some SDK code gen issues

### DIFF
--- a/toolkit/src/main/cpp/include/util.h
+++ b/toolkit/src/main/cpp/include/util.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2024-present Meta Platforms, Inc. and affiliates. All rights reserved.
+
+#pragma once
+
+#include <godot_cpp/templates/local_vector.hpp>
+
+struct CharStringList {
+	LocalVector<CharString> list;
+	LocalVector<const char *> pointers;
+
+	CharStringList(const PackedStringArray &p_array) {
+		list.resize(p_array.size());
+		pointers.resize(p_array.size());
+		for (int i = 0; i < p_array.size(); i++) {
+			list[i] = p_array[i].utf8();
+			pointers[i] = list[i].get_data();
+		}
+	}
+};

--- a/toolkit/src/main/cpp/platform_sdk/meta_platform_sdk.cpp
+++ b/toolkit/src/main/cpp/platform_sdk/meta_platform_sdk.cpp
@@ -166,6 +166,44 @@ uint64_t MetaPlatformSDK_HttpTransferUpdate::get_id() const {
 #endif
 }
 
+PackedByteArray MetaPlatformSDK_ChallengeEntry::get_extra_data() const {
+#ifdef ANDROID_ENABLED
+	PackedByteArray result;
+
+	const char *data = ovr_ChallengeEntry_GetExtraData(handle);
+	if (data) {
+		size_t size = ovr_ChallengeEntry_GetExtraDataLength(handle);
+		if (size > 0) {
+			result.resize(size);
+			memcpy(result.ptrw(), data, size);
+		}
+	}
+
+	return result;
+#else
+	return PackedByteArray();
+#endif
+}
+
+PackedByteArray MetaPlatformSDK_LeaderboardEntry::get_extra_data() const {
+#ifdef ANDROID_ENABLED
+	PackedByteArray result;
+
+	const char *data = ovr_LeaderboardEntry_GetExtraData(handle);
+	if (data) {
+		size_t size = ovr_LeaderboardEntry_GetExtraDataLength(handle);
+		if (size > 0) {
+			result.resize(size);
+			memcpy(result.ptrw(), data, size);
+		}
+	}
+
+	return result;
+#else
+	return PackedByteArray();
+#endif
+}
+
 PackedByteArray MetaPlatformSDK_HttpTransferUpdate::get_bytes() const {
 #ifdef ANDROID_ENABLED
 	PackedByteArray result;


### PR DESCRIPTION
Fixes a few problems in the generated Platform SDK functions:
- Updates `MetaPlatformSDK_LeaderboardEntry::get_extra_data()`/`MetaPlatformSDK_ChallengeEntry::get_extra_data()` to be handwritten as these should be returning `PackedByteArray` instead of String.
- Added the `error` property to `MetaPlatformSDK_Message`.
- Apply a conversion to UTF-8 when passing a `PackedStringArray` to Platform SDK functions.