### PR TITLE
Remove `*_long()` suffix from function names

### DIFF
--- a/doc_classes/MetaPlatformSDK_AssetFileDownloadUpdate.xml
+++ b/doc_classes/MetaPlatformSDK_AssetFileDownloadUpdate.xml
@@ -12,10 +12,10 @@
 		<member name="asset_id" type="int" setter="" getter="get_asset_id" default="0">
 			ID of the asset file.
 		</member>
-		<member name="bytes_total_long" type="int" setter="" getter="get_bytes_total_long" default="0">
+		<member name="bytes_total" type="int" setter="" getter="get_bytes_total" default="0">
 			Total number of bytes.
 		</member>
-		<member name="bytes_transferred_long" type="int" setter="" getter="get_bytes_transferred_long" default="0">
+		<member name="bytes_transferred" type="int" setter="" getter="get_bytes_transferred" default="0">
 			Number of bytes that have been downloaded.
 		</member>
 		<member name="completed" type="bool" setter="" getter="get_completed" default="false">

--- a/generate_platform_sdk_bindings.py
+++ b/generate_platform_sdk_bindings.py
@@ -412,6 +412,10 @@ FUNCTION_RENAMES = {
         # Not caught by current filters to remove 'ovr_'.
         'ovr_message_type_is_notification': 'message_type_is_notification',
     },
+    'MetaPlatformSDK_AssetFileDownloadUpdate': {
+        'get_bytes_total_long': 'get_bytes_total',
+        'get_bytes_transferred_long': 'get_bytes_transferred',
+    },
 }
 
 # Enums using their Godot names (not the OVR ones) to keep, even though they are unused.


### PR DESCRIPTION
These functions had `*_long` in their name to differentiate them from deprecated functions that return `int` (32-bit, rather than 64-bit). Since we only have the one, and all integers in Godot are 64-bit, the `*_long` suffix is just confusing.

This PR removes it!