### PR TITLE
Include API documentation in the editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .cxx
 local.properties
 /thirdparty/ovr_platform_sdk/
+/toolkit/src/gen/
 
 # Binaries
 *.o

--- a/SConstruct
+++ b/SConstruct
@@ -32,6 +32,10 @@ sources += Glob("#toolkit/src/main/cpp/export/*.cpp")
 sources += Glob("#toolkit/src/main/cpp/platform_sdk/*.cpp")
 sources += Glob("#toolkit/gen/src/*.cpp")
 
+if env["target"] in ["editor", "template_debug"]:
+  doc_data = env.GodotCPPDocData("#toolkit/src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+  sources.append(doc_data)
+
 binary_path = '#demo/addons/godot_meta_toolkit/.bin'
 android_src_path = '#toolkit/src'
 project_name = 'godot_meta_toolkit'


### PR DESCRIPTION
I hate that I noticed this only a couple hours _after_ making the 1.0.1 release :-/

We weren't including the API documentation in the GDExtension itself so it could be read in the editor. This PR fixes that!

Given that the docs can be read online, I don't know that this on it's own is worth making a 1.0.2 release right away? I think we can hang on to it until we gather up a couple more fixes, which are sure to happen after the public announcement and more folks are testing it