### PR TITLE
Add Meta Prebuilt APK Install Tool

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -98,9 +98,15 @@ jobs:
       - name: Create extension library
         run: |
           cd godot_meta_toolkit
-          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
+          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
+          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
           cd ..
+      - name: Create Android editor extension library
+        run: |
+          cd godot_meta_toolkit
+          scons platform=${{ matrix.platform }} target=editor ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
+          cd ..
+        if: matrix.platform == 'android'
       - name: Save Godot build cache
         uses: ./godot_meta_toolkit/thirdparty/godot-cpp/.github/actions/godot-cache-save
         with:
@@ -124,6 +130,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: godot_meta_toolkit
+          submodules: recursive
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
       - name: Download Meta Platform SDK
@@ -141,6 +148,13 @@ jobs:
           distribution: "adopt"
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
+      - name: Set up Python (for SCons)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install scons
+        run: |
+          python -m pip install scons==4.0.0
       - name: Copy Android binaries
         run: |
           mkdir -p godot_meta_toolkit/toolkit/src/main/libs/debug/arm64-v8a/arm64-v8a
@@ -152,6 +166,8 @@ jobs:
         run: |
           cd godot_meta_toolkit
           ./gradlew build
+          git clone --branch 4.5.1-stable https://github.com/godotengine/godot.git
+          ./gradlew generatePrebuiltApks -PgodotDir=godot
           cd ..
       - name: Create Godot Meta Toolkit Addon
         run: |

--- a/SConstruct
+++ b/SConstruct
@@ -40,7 +40,7 @@ binary_path = '#demo/addons/godot_meta_toolkit/.bin'
 android_src_path = '#toolkit/src'
 project_name = 'godot_meta_toolkit'
 
-if env['platform'] == "android":
+if env['platform'] == "android" and env["target"] != "editor":
     env.Append(LIBPATH=['thirdparty/ovr_platform_sdk/Android/libs/arm64-v8a'])
     env.Append(LIBS=['ovrplatformloader'])
 
@@ -70,7 +70,18 @@ else:
 
 Default(library)
 
-if env["platform"] == "android":
+if env["platform"] == "android" and env["target"] != "editor":
+    # Copy the libovrplatformloader.so files to the addon
+    ovrplatformloader_copy_path = "#thirdparty/ovr_platform_sdk/Android/libs/arm64-v8a/libovrplatformloader.so"
+    ovrplatformloader_copy_dest = "{}/{}/{}/{}/libovrplatformloader.so".format(
+                                              binary_path,
+                                              env["platform"],
+                                              env["target"],
+                                              env["arch"])
+    ovrplatformloader_copy = env.Command(ovrplatformloader_copy_dest, ovrplatformloader_copy_path, Copy('$TARGET', '$SOURCE'))
+    Default(ovrplatformloader_copy)
+
+    # Copy the libgodot_meta_toolkit.so files to the project libs directory
     android_target = "release" if env["target"] == "template_release" else "debug"
     android_arch = ""
     if env["arch"] == "arm64":

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,27 @@ plugins {}
 
 apply from: 'config.gradle'
 
+ext {
+    godotDir = project.hasProperty("godotDir") ? project.property("godotDir") : ""
+    godotJavaDir = "${godotDir}/platform/android/java/"
+
+    godotAppStandardManifestDir = "${godotJavaDir}/app/src/standard/"
+    godotAppOutputDir = "${godotJavaDir}/app/build/outputs/apk/standard/"
+
+    toolkitAarOutputDir = "toolkit/build/outputs/aar/"
+    toolkitDebugAar = "${toolkitAarOutputDir}/godot_meta_toolkit-debug.aar"
+    toolkitReleaseAar = "${toolkitAarOutputDir}/godot_meta_toolkit-release.aar"
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 
     // Delete the bin directory for the 'godot_meta_toolkit' addon
     delete("demo/addons/godot_meta_toolkit/.bin")
+
+    dependsOn 'cleanPrebuiltApks'
+
+    dependsOn 'cleanScons'
 
     dependsOn ':toolkit:clean'
 }
@@ -39,10 +55,16 @@ task buildToolkit {
 }
 
 /**
- * Build the scons artifacts for the project
+ * Generate the addon by building the 'toolkit' module
  */
-task buildSconsArtifacts {
-    // Find scons' executable path
+task generateAddon {
+    dependsOn buildToolkit
+}
+
+/*
+ * Find scons executable path
+ */
+def getSconsExecutableFile() {
     File sconsExecutableFile = null
     def sconsName = "scons"
     def sconsExts = (org.gradle.internal.os.OperatingSystem.current().isWindows()
@@ -66,40 +88,261 @@ task buildSconsArtifacts {
         }
     }
 
+    return sconsExecutableFile
+}
+
+/**
+ * Utility method to create common scons tasks for use by other tasks.
+ */
+def createSconsTasks(File sconsExecutableFile, boolean clean) {
+    def defaultArgs = [
+            "--directory=.",
+            "custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json",
+            "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json",
+    ]
+
+    if (clean) {
+        defaultArgs << "-c"
+    }
+
+    def taskPrefix = (clean ? "clean" : "build")
+
+    // Android.
+    tasks.create(name: "${taskPrefix}GodotMetaToolkitAndroidArm64Debug", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args defaultArgs + ["platform=android", "target=template_debug", "arch=arm64"]
+    }
+    tasks.create(name: "${taskPrefix}GodotMetaToolkitAndroidArm64Release", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args defaultArgs + ["platform=android", "target=template_release", "arch=arm64"]
+    }
+    tasks.create(name: "${taskPrefix}GodotMetaToolkitAndroidArm64Editor", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args defaultArgs + ["platform=android", "target=editor", "arch=arm64"]
+    }
+
+    // Desktop.
+    tasks.create(name: "${taskPrefix}GodotMetaToolkitDesktopDebug", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args defaultArgs + ["target=template_debug"]
+    }
+    tasks.create(name: "${taskPrefix}GodotMetaToolkitDesktopRelease", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args defaultArgs + ["target=template_release"]
+    }
+}
+
+/**
+ * Build the scons artifacts for the project
+ */
+task buildSconsArtifacts {
+    File sconsExecutableFile = getSconsExecutableFile()
+
     // Using `doFirst` so the exception doesn't happen until this task actually runs.
     doFirst {
         if (sconsExecutableFile == null) {
-            throw new GradleException("Unable to find executable path for the '$sconsName' command.")
+            throw new GradleException("Unable to find executable path for the 'scons' command.")
         } else {
-            logger.debug("Found executable path for $sconsName: ${sconsExecutableFile.absolutePath}")
+            logger.debug("Found executable path for scons: ${sconsExecutableFile.absolutePath}")
         }
     }
 
     if (sconsExecutableFile != null) {
-        // Build the GDExtension library for Android.
-        tasks.create(name: "buildGodotMetaToolkitAndroidArm64Debug", type: Exec) {
-            executable sconsExecutableFile.absolutePath
-            args "--directory=.", "platform=android", "target=template_debug", "arch=arm64", "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json"
-        }
-        tasks.create(name: "buildGodotMetaToolkitAndroidArm64Release", type: Exec) {
-            executable sconsExecutableFile.absolutePath
-            args "--directory=.", "platform=android", "target=template_release", "arch=arm64", "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json"
-        }
+        createSconsTasks(sconsExecutableFile, false)
 
+        // Android.
         dependsOn 'buildGodotMetaToolkitAndroidArm64Debug'
         dependsOn 'buildGodotMetaToolkitAndroidArm64Release'
+        dependsOn 'buildGodotMetaToolkitAndroidArm64Editor'
 
-        // Build the GDExtension library for desktop.
-        tasks.create(name: "buildGodotMetaToolkitDesktopDebug", type: Exec) {
-            executable sconsExecutableFile.absolutePath
-            args "--directory=.", "target=template_debug", "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json"
-        }
-        tasks.create(name: "buildGodotMetaToolkitDesktopRelease", type: Exec) {
-            executable sconsExecutableFile.absolutePath
-            args "--directory=.", "target=template_release", "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json"
-        }
-
+        // Desktop.
         dependsOn 'buildGodotMetaToolkitDesktopDebug'
         dependsOn 'buildGodotMetaToolkitDesktopRelease'
     }
+}
+
+/**
+ * Scons clean for the project
+ */
+task cleanScons {
+    File sconsExecutableFile = getSconsExecutableFile()
+
+    // Using `doFirst` so the exception doesn't happen until this task actually runs.
+    doFirst {
+        if (sconsExecutableFile == null) {
+            throw new GradleException("Unable to find executable path for the 'scons' command.")
+        } else {
+            logger.debug("Found executable path for scons: ${sconsExecutableFile.absolutePath}")
+        }
+    }
+
+    if (sconsExecutableFile != null) {
+        createSconsTasks(sconsExecutableFile, true)
+
+        // Android.
+        dependsOn 'cleanGodotMetaToolkitAndroidArm64Debug'
+        dependsOn 'cleanGodotMetaToolkitAndroidArm64Release'
+        dependsOn 'cleanGodotMetaToolkitAndroidArm64Editor'
+
+        // Desktop.
+        dependsOn 'cleanGodotMetaToolkitDesktopDebug'
+        dependsOn 'cleanGodotMetaToolkitDesktopRelease'
+    }
+}
+
+/**
+ * Cleans the generated prebuilt apks.
+ */
+task cleanPrebuiltApks(type: Delete) {
+    def gradlewExecutablePath = "./gradlew" + (org.gradle.internal.os.OperatingSystem.current().isWindows() ? ".bat" : "")
+    File gradlewExecutable = file(gradlewExecutablePath)
+
+    doFirst {
+        if (!gradlewExecutable.exists()) {
+            throw new GradleException("Unable to find executable path for the 'gradlew' script.")
+        }
+    }
+
+    delete "meta-export-template.zip"
+
+    if (godotDir != "") {
+        delete(godotAppStandardManifestDir)
+
+        tasks.create(name: "cleanGodot", type: Exec) {
+            executable gradlewExecutable.absolutePath
+            args "-p", godotJavaDir, "clean"
+        }
+        dependsOn 'cleanGodot'
+    }
+}
+
+/**
+ * Copy the prebuilt manifest to the Godot::app module. The manifest contains additional meta-data
+ * that this plugin modifies at export time based on the project configuration.
+ */
+task copyPrebuiltManifestToGodotApp(type: Copy) {
+    // Copy the prebuilt manifest
+    file(godotAppStandardManifestDir).mkdirs()
+
+    from "./prebuilt/AndroidManifest.xml"
+    into godotAppStandardManifestDir 
+}
+
+/**
+ * Zip the generated prebuilt apks
+ */
+task zipPrebuiltApks(type: Zip) {
+    from(godotAppOutputDir)
+    include '**/*.apk'
+    archiveFileName = "meta-export-template.zip"
+    destinationDirectory = project.rootDir
+}
+
+void verifyGodotDir() {
+    if (godotDir == "" || !file(godotDir).exists() || !file(godotDir).isDirectory()) {
+        throw new GradleException("godotDir property is empty or invalid.")
+    }
+}
+
+/**
+ * Parse the OpenXR loader version from the openxr.h header file in godotDir.
+ */
+String getOpenXrLoaderVersion() {
+    verifyGodotDir()
+
+    File openxrHeader = file("${godotDir}/thirdparty/openxr/include/openxr/openxr.h")
+    if (!openxrHeader.exists()) {
+        throw new GradleException("Unable to find openxr.h at: ${openxrHeader.absolutePath}")
+    }
+
+    def versionLine = openxrHeader.readLines().find { line ->
+      line.contains("#define XR_CURRENT_API_VERSION")
+    }
+
+    if (versionLine == null) {
+        throw new GradleException("Unable to locate API version define in openxr.h")
+    }
+
+    def version = versionLine.findAll(/\d+/).join(".")
+    if (version == "") {
+        throw new GradleException("Unable to parse version number from OpenXR version")
+    }
+
+    return version
+}
+
+
+/**
+ * Generate the prebuilt apks.
+ */
+task generatePrebuiltApks() {
+    def gradlewExecutablePath = "./gradlew" + (org.gradle.internal.os.OperatingSystem.current().isWindows() ? ".bat" : "")
+    File gradlewExecutable = file(gradlewExecutablePath)
+
+    File sconsExecutableFile = getSconsExecutableFile()
+
+    doFirst {
+        if (!gradlewExecutable.exists()) {
+            throw new GradleException("Unable to find executable path for the 'gradlew' script.")
+        }
+    }
+
+    if (sconsExecutableFile != null && sconsExecutableFile.exists()) {
+        tasks.create(name: "buildGodotAndroidArm64Debug", type: Exec) {
+            doFirst {
+                verifyGodotDir()
+            }
+            executable sconsExecutableFile.absolutePath
+            args "--directory=${godotDir}", "platform=android", "target=template_debug", "arch=arm64"
+        }
+
+        tasks.create(name: "buildGodotAndroidArm64Release", type: Exec) {
+            doFirst {
+                verifyGodotDir()
+            }
+            executable sconsExecutableFile.absolutePath
+            args "--directory=${godotDir}", "platform=android", "target=template_release", "arch=arm64"
+        }
+    }
+
+    tasks.create(name: "assemblePrebuiltDebugApk", type: Exec) {
+        dependsOn 'copyPrebuiltManifestToGodotApp'
+        dependsOn ':toolkit:assembleDebug'
+
+        if (sconsExecutableFile != null && sconsExecutableFile.exists()) {
+            dependsOn 'buildGodotAndroidArm64Debug'
+        }
+        doFirst {
+            verifyGodotDir()
+            args "-p",
+                    godotJavaDir,
+                    ":app:assembleStandardDebug",
+                    "-Pplugins_remote_binaries=org.godotengine:godot-openxr-vendors-meta:$versions.openxrVendorsVersion|org.khronos.openxr:openxr_loader_for_android:${getOpenXrLoaderVersion()}",
+                    "-Pplugins_local_binaries=${file(toolkitDebugAar).absolutePath}"
+        }
+        executable gradlewExecutable.absolutePath
+    }
+
+    tasks.create(name: "assemblePrebuiltReleaseApk", type: Exec) {
+        dependsOn 'copyPrebuiltManifestToGodotApp'
+        dependsOn ':toolkit:assembleRelease'
+
+        if (sconsExecutableFile != null && sconsExecutableFile.exists()) {
+            dependsOn 'buildGodotAndroidArm64Release'
+        }
+        doFirst {
+            verifyGodotDir()
+            args "-p",
+                    godotJavaDir,
+                    ":app:assembleStandardRelease",
+                    "-Pplugins_remote_binaries=org.godotengine:godot-openxr-vendors-meta:$versions.openxrVendorsVersion|org.khronos.openxr:openxr_loader_for_android:${getOpenXrLoaderVersion()}",
+                    "-Pplugins_local_binaries=${file(toolkitReleaseAar).absolutePath}"
+        }
+        executable gradlewExecutable.absolutePath
+    }
+
+    dependsOn 'assemblePrebuiltDebugApk'
+    dependsOn 'assemblePrebuiltReleaseApk'
+
+    finalizedBy 'zipPrebuiltApks'
 }

--- a/config.gradle
+++ b/config.gradle
@@ -1,12 +1,13 @@
 ext {
     versions = [
-            gradlePluginVersion     : '8.2.0',
-            compileSdk              : 34,
-            minSdk                  : 21,
-            targetSdk               : 34,
+            gradlePluginVersion     : '8.6.1',
+            compileSdk              : 35,
+            minSdk                  : 24,
+            targetSdk               : 35,
             javaVersion             : JavaVersion.VERSION_17,
-            kotlinVersion           : '1.9.20',
-            ndkVersion              : '23.2.8568313'
+            kotlinVersion           : '2.1.20',
+            ndkVersion              : '28.1.13356709',
+            openxrVendorsVersion    : '4.2.2-stable'
     ]
 
     libraries = [
@@ -16,7 +17,7 @@ ext {
 
 // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
 ext.getReleaseVersion = { ->
-    final String defaultVersion = "0.1.0-dev-SNAPSHOT"
+    final String defaultVersion = "1.0.4-stable"
 
     String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
     if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/demo/addons/godot_meta_toolkit/.gitignore
+++ b/demo/addons/godot_meta_toolkit/.gitignore
@@ -1,2 +1,3 @@
 .bin/
+.build_template/
 build/

--- a/demo/addons/godot_meta_toolkit/toolkit.gdextension
+++ b/demo/addons/godot_meta_toolkit/toolkit.gdextension
@@ -6,11 +6,23 @@ android_aar_plugin = true
 
 [libraries]
 
-android.debug.arm64 = "res://addons/godot_meta_toolkit/.bin/android/template_debug/arm64/libgodot_meta_toolkit.so"
-android.release.arm64 = "res://addons/godot_meta_toolkit/.bin/android/template_release/arm64/libgodot_meta_toolkit.so"
+android.debug.template.arm64 = "res://addons/godot_meta_toolkit/.bin/android/template_debug/arm64/libgodot_meta_toolkit.so"
+android.release.template.arm64 = "res://addons/godot_meta_toolkit/.bin/android/template_release/arm64/libgodot_meta_toolkit.so"
+android.editor_runtime.arm64 = "res://addons/godot_meta_toolkit/.bin/android/template_debug/arm64/libgodot_meta_toolkit.so"
+android.editor_hint.arm64 = "res://addons/godot_meta_toolkit/.bin/android/editor/arm64/libgodot_meta_toolkit.so"
 macos.debug = "res://addons/godot_meta_toolkit/.bin/macos/template_debug/libgodot_meta_toolkit.macos.framework"
 macos.release = "res://addons/godot_meta_toolkit/.bin/macos/template_release/libgodot_meta_toolkit.macos.framework"
 windows.debug.x86_64 = "res://addons/godot_meta_toolkit/.bin/windows/template_debug/x86_64/libgodot_meta_toolkit.dll"
 windows.release.x86_64 = "res://addons/godot_meta_toolkit/.bin/windows/template_release/x86_64/libgodot_meta_toolkit.dll"
 linux.debug.x86_64 = "res://addons/godot_meta_toolkit/.bin/linux/template_debug/x86_64/libgodot_meta_toolkit.so"
 linux.release.x86_64 = "res://addons/godot_meta_toolkit/.bin/linux/template_release/x86_64/libgodot_meta_toolkit.so"
+
+[dependencies]
+
+android.debug.arm64 = {
+"res://addons/godot_meta_toolkit/.bin/android/template_debug/arm64/libovrplatformloader.so" : ""
+}
+
+android.release.arm64 = {
+"res://addons/godot_meta_toolkit/.bin/android/template_release/arm64/libovrplatformloader.so" : ""
+}

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://c0ol8en13wpk3"]
 
-[ext_resource type="Script" uid="uid://85h8678hfmqi" path="res://main.gd" id="1_t3hrc"]
+[ext_resource type="Script" uid="uid://bp3gnieyxmcir" path="res://main.gd" id="1_t3hrc"]
 [ext_resource type="Script" uid="uid://qb2g8p5s3m8x" path="res://raycast.gd" id="2_5nsls"]
 [ext_resource type="Texture2D" uid="uid://cmm67scocnrpg" path="res://icon.svg" id="3_qj576"]
 

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -19,6 +19,10 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[debug]
+
+settings/stdout/verbose_stdout=true
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/generate_platform_sdk_bindings.py
+++ b/generate_platform_sdk_bindings.py
@@ -1042,17 +1042,17 @@ def generate_header(class_name, class_def, plan):
     if class_name != 'MetaPlatformSDK':
         lines.append('#include "platform_sdk/meta_platform_sdk.h"')
         lines.append('')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         for ovr_header in class_def['ovr_headers']:
             lines.append(f'#include <{ovr_header}>')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
     else:
         lines.append('#include <godot_cpp/classes/ref.hpp>')
         lines.append('#include <godot_cpp/templates/hash_map.hpp>')
         lines.append('')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('#include <OVR_Types.h>')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
         lines.append('#include "platform_sdk/meta_platform_sdk_request.h"')
     lines.append('')
@@ -1083,15 +1083,15 @@ def generate_header(class_name, class_def, plan):
     if class_def['type'] == 'singleton':
         lines.append(f'\tstatic {class_name} *singleton;')
         lines.append('')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('\tbool _platform_initialized = false;')
         lines.append('\tHashMap<ovrRequest, Ref<MetaPlatformSDK_Request>> requests;')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
     else:
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f'\t{class_def["ovr_handle"]} handle = nullptr;')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
     if class_name == 'MetaPlatformSDK_Message':
         lines.append('\tMetaPlatformSDK::MessageType type = MetaPlatformSDK::MESSAGE_UNKNOWN;')
@@ -1129,20 +1129,20 @@ def generate_header(class_name, class_def, plan):
     if class_name == 'MetaPlatformSDK':
         lines.append(f'\tstatic void _register_generated_classes();')
         lines.append('')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f'\tvoid _initialize_platform();')
         lines.append(f'\tvoid _initialize_platform_async(const Ref<MetaPlatformSDK_Message> &p_message);')
         lines.append(f'\tRef<MetaPlatformSDK_Request> _create_request(ovrRequest p_request);')
         lines.append(f'\tvoid _process_messages();')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
         lines.append(f'\tPlatformInitializeResult initialize_platform(const String &p_app_id, const Dictionary &p_options);')
         lines.append(f'\tRef<MetaPlatformSDK_Request> initialize_platform_async(const String &p_app_id);')
     else:
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f'\tstatic Ref<{class_name}> _create_with_ovr_handle({class_def["ovr_handle"]} p_handle);')
         lines.append(f'\tinline {class_def["ovr_handle"]} _get_ovr_handle() {{ return handle; }}')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
     if class_name == 'MetaPlatformSDK_Message':
         lines.append('\tinline MetaPlatformSDK::MessageType get_type() const { return type; }')
@@ -1203,10 +1203,10 @@ def generate_source(class_name, class_def, plan):
 
     if class_name == 'MetaPlatformSDK':
         lines.append('')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         for ovr_header in class_def['ovr_headers']:
             lines.append(f'#include <{ovr_header}>')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
 
         # Include all the other classes so we can register them.
@@ -1215,10 +1215,10 @@ def generate_source(class_name, class_def, plan):
                 continue
             lines.append(f'#include "platform_sdk/{camel_to_snake_case(other_class_name)}.h"')
     elif class_name == 'MetaPlatformSDK_Message':
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         # Needed for ovr_FreeMessage().
         lines.append(f'#include <OVR_Platform.h>')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
 
     lines.append('')
 
@@ -1338,7 +1338,7 @@ def generate_source(class_name, class_def, plan):
         null_return_value = make_null_value(function['return'], plan)
 
         lines.append(make_function_decl(function_name, function, class_name) + ' {')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
 
         # Check that we are initialized.
         if class_def['ovr_handle']:
@@ -1405,7 +1405,7 @@ def generate_source(class_name, class_def, plan):
             lines.append('#else')
             lines.append(f'\treturn {null_return_value};')
 
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('}')
         lines.append('')
 
@@ -1416,15 +1416,15 @@ def generate_source(class_name, class_def, plan):
         lines.append('');
         lines.append('\tsingleton = this;')
     elif class_def['type'] == 'model':
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f"\thandle = {class_def['create_func']['name']}();")
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
     lines.append('}')
     lines.append('')
 
     # Creation from handle.
     if class_def['type'] == 'result':
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f'Ref<{class_name}> {class_name}::_create_with_ovr_handle({class_def["ovr_handle"]} p_handle) {{')
         lines.append(f'\tRef<{class_name}> inst;')
         lines.append('\tif (p_handle != nullptr) {')
@@ -1435,7 +1435,7 @@ def generate_source(class_name, class_def, plan):
         lines.append('\t}')
         lines.append('\treturn inst;')
         lines.append('}')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('')
 
     # Destructor.
@@ -1443,15 +1443,15 @@ def generate_source(class_name, class_def, plan):
     if class_def['type'] == 'singleton':
         lines.append('\tsingleton = nullptr;')
     elif class_def['type'] == 'model':
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append(f"\t{class_def['destroy_func']['name']}(handle);")
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
     elif class_def['type'] == 'result' and 'free_func' in class_def:
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('\tif (handle) {')
         lines.append(f"\t\t{class_def['free_func']['name']}(handle);")
         lines.append('\t}')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
     lines.append('}')
     lines.append('')
 
@@ -1472,7 +1472,7 @@ def generate_source(class_name, class_def, plan):
         #
 
         lines.append('Variant MetaPlatformSDK_Message::get_data() const {')
-        lines.append('#ifdef ANDROID_ENABLED')
+        lines.append('#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('\tERR_FAIL_COND_V(type == MetaPlatformSDK::MessageType::MESSAGE_UNKNOWN, Variant());')
         lines.append('')
         lines.append('\tif (data.get_type() != Variant::NIL) {')
@@ -1503,7 +1503,7 @@ def generate_source(class_name, class_def, plan):
         lines.append('\treturn data;')
         lines.append('#else')
         lines.append('\treturn Variant();')
-        lines.append('#endif // ANDROID_ENABLED')
+        lines.append('#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)')
         lines.append('}')
         lines.append('')
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Mon Mar 25 17:51:26 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/prebuilt/AndroidManifest.xml
+++ b/prebuilt/AndroidManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name=".GodotApp">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android
+                platforms. -->
+                <category android:name="com.oculus.intent.category.VR" />
+                <!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
+                See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
+                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            </intent-filter>
+        </activity>
+        <activity-alias
+            android:name=".GodotAppLauncher"
+            android:exported="true"
+            android:targetActivity=".GodotApp"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android
+                platforms. -->
+                <category android:name="com.oculus.intent.category.VR" />
+
+                <!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
+                See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
+                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            </intent-filter>
+        </activity-alias>
+
+        <meta-data android:name="com.oculus.supportedDevices" tools:node="remove" />
+    </application>
+
+</manifest>

--- a/thirdparty/godot_cpp_build_profile/build_profile.json
+++ b/thirdparty/godot_cpp_build_profile/build_profile.json
@@ -8,22 +8,27 @@
         "ConfirmationDialog",
         "Container",
         "Control",
+        "DirAccess",
         "EditorExportPlatform",
         "EditorExportPlatformAndroid",
         "EditorExportPlugin",
         "EditorFileDialog",
         "EditorInterface",
+        "EditorPaths",
         "EditorPlugin",
         "EditorSettings",
         "Engine",
         "FileAccess",
         "HBoxContainer",
+        "HTTPClient",
+        "HTTPRequest",
         "Label",
         "LineEdit",
         "MainLoop",
         "Node",
         "OS",
         "ProjectSettings",
+        "ProgressBar",
         "RefCounted",
         "Resource",
         "RichTextLabel",
@@ -34,6 +39,9 @@
         "Texture2D",
         "VBoxContainer",
         "Viewport",
-        "Window"
+        "Window",
+        "XRInterface",
+        "ZIPReader"
     ]
 }
+

--- a/thirdparty/godot_cpp_gdextension_api/README.md
+++ b/thirdparty/godot_cpp_gdextension_api/README.md
@@ -1,0 +1,27 @@
+# GDExtension API
+
+This directory contains the API JSON for
+[**Godot Engine**](https://github.com/godotengine/godot)'s *GDExtensions* API.
+
+## Current API version
+- [commit fbbf9ec4efd8f1055d00edb8d926eef8ba4c2cce](https://github.com/godotengine/godot/commit/fbbf9ec4efd8f1055d00edb8d926eef8ba4c2cce)
+
+## Current API modifications
+
+- The `_update_android_prebuilt_manifest` method for `EditorExportPlugin`
+
+## Updating API
+
+The API JSON is synced with the latest version of Godot used when developing the plugin. Here is the
+update procedure:
+
+- Compile [Godot Engine](https://github.com/godotengine/godot) at the specific
+  version/commit which you are using.
+  * Or if you use an official release, download that version of the Godot editor.
+- Use the compiled or downloaded executable to generate the `extension_api.json` file with:
+
+```
+godot --dump-extension-api
+```
+- Copy the generated `extension_api.json` file into this directory
+- List any additional modifications under Current API modifications

--- a/toolkit/src/main/cpp/editor/meta_export_template_dialog.cpp
+++ b/toolkit/src/main/cpp/editor/meta_export_template_dialog.cpp
@@ -1,0 +1,329 @@
+// Copyright (c) 2024-present Meta Platforms, Inc. and affiliates. All rights reserved.
+
+#include "editor/meta_export_template_dialog.h"
+#include "version.h"
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/dir_access.hpp>
+#include <godot_cpp/classes/editor_file_dialog.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_paths.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/http_request.hpp>
+#include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/progress_bar.hpp>
+#include <godot_cpp/classes/v_box_container.hpp>
+#include <godot_cpp/classes/zip_reader.hpp>
+
+static const char *META_EXPORT_TEMPLATE_MISSING = "Meta export template is missing, click the Download button to download and install.";
+static const char *META_EXPORT_TEMPLATE_ALREADY_INSTALLED = "Meta export template is already installed in this project and it won't be overwritten.\nRemove the res://addons/godot_meta_toolkit/.build_template directory manually before attempting this operation again.";
+static const char *META_EXPORT_TEMPLATE_PREBUILT_DIR = "res://addons/godot_meta_toolkit/.build_template/prebuilt";
+
+void MetaExportTemplateDialog::_bind_methods() {
+}
+
+void MetaExportTemplateDialog::_notification(uint32_t p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			VBoxContainer *main_vbox = memnew(VBoxContainer);
+			main_vbox->set_anchors_preset(Control::LayoutPreset::PRESET_FULL_RECT);
+			add_child(main_vbox);
+
+			download_progress_bar = memnew(ProgressBar);
+			download_progress_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			download_progress_bar->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+			download_progress_bar->set_min(0);
+			download_progress_bar->set_max(1);
+			download_progress_bar->set_value(0);
+			download_progress_bar->set_step(0.01);
+			download_progress_bar->set_editor_preview_indeterminate(true);
+
+			main_vbox->add_child(download_progress_bar);
+			message = memnew(Label);
+			message->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			message->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+			main_vbox->add_child(message);
+
+			download_button = add_button("Download");
+			download_button->connect("pressed", callable_mp(this, &MetaExportTemplateDialog::_download_template));
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible()) {
+				set_process(false);
+				is_downloading_template = false;
+			}
+		} break;
+
+		case NOTIFICATION_PROCESS: {
+			update_countdown -= get_process_delta_time();
+			if (update_countdown > 0) {
+				return;
+			}
+			update_countdown = 0.5;
+
+			String status;
+			int downloaded_bytes;
+			int total_bytes;
+			bool success = _humanize_http_status(download_request, status, downloaded_bytes, total_bytes);
+
+			if (downloaded_bytes >= 0) {
+				if (total_bytes > 0) {
+					_set_current_progress_value(float(downloaded_bytes) / total_bytes, status);
+				} else {
+					_set_current_progress_value(0, status);
+				}
+			} else {
+				_set_current_progress_status(status);
+			}
+
+			if (!success) {
+				set_process(false);
+				is_downloading_template = false;
+			}
+		} break;
+	}
+}
+
+bool MetaExportTemplateDialog::_humanize_http_status(HTTPRequest *p_request, String &r_status, int &r_downloaded_bytes, int &r_total_bytes) {
+	r_status = "";
+	r_downloaded_bytes = -1;
+	r_total_bytes = -1;
+	bool success = true;
+
+	switch (p_request->get_http_client_status()) {
+		case HTTPClient::STATUS_DISCONNECTED:
+			r_status = "Disconnected";
+			success = false;
+			break;
+		case HTTPClient::STATUS_RESOLVING:
+			r_status = "Resolving";
+			break;
+		case HTTPClient::STATUS_CANT_RESOLVE:
+			r_status = "Can't Resolve";
+			success = false;
+			break;
+		case HTTPClient::STATUS_CONNECTING:
+			r_status = "Connecting...";
+			break;
+		case HTTPClient::STATUS_CANT_CONNECT:
+			r_status = "Can't Connect";
+			success = false;
+			break;
+		case HTTPClient::STATUS_CONNECTED:
+			r_status = "Connected";
+			break;
+		case HTTPClient::STATUS_REQUESTING:
+			r_status = "Requesting...";
+			break;
+		case HTTPClient::STATUS_BODY:
+			r_status = "Downloading";
+			r_downloaded_bytes = p_request->get_downloaded_bytes();
+			r_total_bytes = p_request->get_body_size();
+
+			if (p_request->get_body_size() > 0) {
+				r_status += " " + String::humanize_size(p_request->get_downloaded_bytes()) + "/" + String::humanize_size(p_request->get_body_size());
+			} else {
+				r_status += " " + String::humanize_size(p_request->get_downloaded_bytes());
+			}
+			break;
+		case HTTPClient::STATUS_CONNECTION_ERROR:
+			r_status = "Connection Error";
+			success = false;
+			break;
+		case HTTPClient::STATUS_TLS_HANDSHAKE_ERROR:
+			r_status = "TLS Handshake Error";
+			success = false;
+			break;
+	}
+
+	return success;
+}
+
+void MetaExportTemplateDialog::show() {
+	popup_centered();
+
+	download_progress_bar->hide();
+	message->add_theme_color_override("font_color", get_theme_color(StringName("font_color"), StringName("Label")));
+
+	if (DirAccess::dir_exists_absolute(META_EXPORT_TEMPLATE_PREBUILT_DIR)) {
+		download_button->set_disabled(true);
+		message->set_text(META_EXPORT_TEMPLATE_ALREADY_INSTALLED);
+	} else {
+		download_button->set_disabled(false);
+		message->set_text(META_EXPORT_TEMPLATE_MISSING);
+	}
+}
+
+void MetaExportTemplateDialog::_download_template() {
+	if (is_downloading_template) {
+		return;
+	}
+	is_downloading_template = true;
+
+	if (download_request) {
+		memfree(download_request);
+	}
+
+	download_request = memnew(HTTPRequest);
+	add_child(download_request);
+	download_request->connect("request_completed", callable_mp(this, &MetaExportTemplateDialog::_download_request_completed));
+
+	download_progress_bar->show();
+	download_progress_bar->set_indeterminate(true);
+	_set_current_progress_status("Starting the download...");
+
+	download_request->set_download_file(EditorInterface::get_singleton()->get_editor_paths()->get_cache_dir().path_join("tmp-meta-export-template.zip"));
+	download_request->set_use_threads(true);
+
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	if (editor_interface == nullptr) {
+		_set_current_progress_status(vformat("Failed to get editor interface."), true);
+		return;
+	}
+
+	Ref<EditorSettings> editor_settings = EditorInterface::get_singleton()->get_editor_settings();
+	if (editor_settings.is_null() || !editor_settings->has_setting("network/http_proxy/host") || !editor_settings->has_setting("network/http_proxy/port")) {
+		_set_current_progress_status(vformat("Failed to get editor settings."), true);
+		return;
+	}
+
+	const String proxy_host = editor_settings->get_setting("network/http_proxy/host");
+	const int proxy_port = editor_settings->get_setting("network/http_proxy/port");
+	download_request->set_http_proxy(proxy_host, proxy_port);
+	download_request->set_https_proxy(proxy_host, proxy_port);
+
+	if (!editor_settings->has_setting("xr/meta_toolkit/base_download_url")) {
+		_set_current_progress_status(vformat("No base download URL for Meta toolkit found in editor settings."), true);
+		return;
+	}
+
+	const GDExtensionGodotVersion &godot_version = godot::internal::godot_version;
+	String filename = vformat("meta-export-template-v%d.%d.%d", godot_version.major, godot_version.minor, godot_version.patch);
+	String download_url = (String)editor_settings->get_setting("xr/meta_toolkit/base_download_url") + GODOT_META_TOOLKIT_VERSION + "/" + filename;
+	Error err = download_request->request(download_url);
+	if (err != OK) {
+		_set_current_progress_status(vformat("Error requesting URL: %s", download_url), true);
+		return;
+	}
+
+	set_process(true);
+	_set_current_progress_status("Connecting to the mirror...");
+}
+
+void MetaExportTemplateDialog::_set_current_progress_value(float p_value, const String &p_status) {
+	download_progress_bar->show();
+	download_progress_bar->set_indeterminate(false);
+	download_progress_bar->set_value(p_value);
+	message->set_text(p_status);
+}
+
+void MetaExportTemplateDialog::_set_current_progress_status(const String &p_status, bool p_error) {
+	message->set_text(p_status);
+
+	if (p_error) {
+		download_progress_bar->hide();
+		message->add_theme_color_override("font_color", get_theme_color(StringName("error_color"), StringName("Editor")));
+	} else {
+		message->add_theme_color_override("font_color", get_theme_color(StringName("font_color"), StringName("Label")));
+	}
+}
+
+void MetaExportTemplateDialog::_download_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data) {
+	switch (p_status) {
+		case HTTPRequest::RESULT_CANT_RESOLVE: {
+			_set_current_progress_status("Can't resolve the requested address.", true);
+		} break;
+		case HTTPRequest::RESULT_BODY_SIZE_LIMIT_EXCEEDED:
+		case HTTPRequest::RESULT_CONNECTION_ERROR:
+		case HTTPRequest::RESULT_CHUNKED_BODY_SIZE_MISMATCH:
+		case HTTPRequest::RESULT_TLS_HANDSHAKE_ERROR:
+		case HTTPRequest::RESULT_CANT_CONNECT: {
+			_set_current_progress_status("Can't connect to the mirror.", true);
+		} break;
+		case HTTPRequest::RESULT_NO_RESPONSE: {
+			_set_current_progress_status("No response from the mirror.", true);
+		} break;
+		case HTTPRequest::RESULT_REQUEST_FAILED: {
+			_set_current_progress_status("Request failed.", true);
+		} break;
+		case HTTPRequest::RESULT_REDIRECT_LIMIT_REACHED: {
+			_set_current_progress_status("Request ended up in a redirect loop.", true);
+		} break;
+		default: {
+			if (p_code != 200) {
+				_set_current_progress_status("Request failed: " + itos(p_code), true);
+			} else {
+				_set_current_progress_status("Download complete; extracting template...");
+				String download_path = download_request->get_download_file();
+				is_downloading_template = false;
+
+				Ref<ZIPReader> zip_reader;
+				zip_reader.instantiate();
+				if (!FileAccess::file_exists(download_path)) {
+					_set_current_progress_status(vformat("Archive not found at path: %s", download_path), true);
+					break;
+				}
+				zip_reader->open(download_path);
+
+				if (DirAccess::dir_exists_absolute(META_EXPORT_TEMPLATE_PREBUILT_DIR)) {
+					_set_current_progress_status("Meta toolkit template directory already exists", true);
+					break;
+				}
+				if (DirAccess::make_dir_recursive_absolute(META_EXPORT_TEMPLATE_PREBUILT_DIR) != OK) {
+					_set_current_progress_status("Error creating Meta toolkit template directory", true);
+					break;
+				}
+
+				Ref<DirAccess> root_dir = DirAccess::open(META_EXPORT_TEMPLATE_PREBUILT_DIR);
+				if (root_dir.is_null()) {
+					_set_current_progress_status("Error opening Meta toolkit template directory", true);
+					break;
+				}
+
+				bool install_failed = false;
+				PackedStringArray files = zip_reader->get_files();
+				for (const String &file_path : files) {
+					if (root_dir->make_dir_recursive(root_dir->get_current_dir().path_join(file_path).get_base_dir()) != OK) {
+						install_failed = true;
+						_set_current_progress_status("Error creating Meta toolkit install directory.", true);
+						break;
+					}
+
+					Ref<FileAccess> file = FileAccess::open(root_dir->get_current_dir().path_join(file_path), FileAccess::WRITE);
+					if (file.is_null()) {
+						install_failed = true;
+						_set_current_progress_status("Error opening Meta toolkit file during installation.", true);
+						break;
+					}
+
+					PackedByteArray buffer = zip_reader->read_file(file_path);
+					file->store_buffer(buffer);
+				}
+
+				if (install_failed) {
+					break;
+				}
+
+				zip_reader->close();
+				if (DirAccess::remove_absolute(download_path) != OK) {
+					WARN_PRINT("Error cleaning up Meta toolkit template download");
+				}
+
+				// Download and install success.
+				download_progress_bar->hide();
+				_set_current_progress_status("Export template setup complete.");
+				download_button->set_disabled(true);
+			}
+		} break;
+	}
+
+	set_process(false);
+}
+
+MetaExportTemplateDialog::MetaExportTemplateDialog() {
+	set_title("Install Meta Export Template");
+	set_ok_button_text("Close");
+}

--- a/toolkit/src/main/cpp/editor/meta_toolkit_editor_plugin.cpp
+++ b/toolkit/src/main/cpp/editor/meta_toolkit_editor_plugin.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2024-present Meta Platforms, Inc. and affiliates. All rights reserved.
 
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+
+#include "editor/meta_export_template_dialog.h"
 #include "editor/meta_toolkit_editor_plugin.h"
 #include "editor/meta_xr_simulator_dialog.h"
 
@@ -9,12 +13,25 @@ void MetaToolkitEditorPlugin::_bind_methods() {
 void MetaToolkitEditorPlugin::_notification(uint32_t p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
+			_add_plugin_editor_settings();
+
 			_meta_xr_simulator_dialog = memnew(MetaXRSimulatorDialog);
 			add_child(_meta_xr_simulator_dialog);
+
+			// Only works with Godot 4.5 or later.
+			if (godot::internal::godot_version.major == 4 && godot::internal::godot_version.minor >= 5) {
+				_meta_export_templates_dialog = memnew(MetaExportTemplateDialog);
+				add_child(_meta_export_templates_dialog);
+			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
 			add_tool_menu_item("Configure Meta XR Simulator...", callable_mp(this, &MetaToolkitEditorPlugin::_configure_xr_simulator));
+
+			// Only works with Godot 4.5 or later.
+			if (godot::internal::godot_version.minor >= 5) {
+				add_tool_menu_item("Install Meta Export Template...", callable_mp(this, &MetaToolkitEditorPlugin::_configure_export_template));
+			}
 
 			// Initialize the editor export plugin
 			_meta_toolkit_export_plugin.instantiate();
@@ -23,6 +40,11 @@ void MetaToolkitEditorPlugin::_notification(uint32_t p_what) {
 
 		case NOTIFICATION_EXIT_TREE: {
 			remove_tool_menu_item("Configure Meta XR Simulator...");
+
+			// Only works with Godot 4.5 or later.
+			if (godot::internal::godot_version.minor >= 5) {
+				remove_tool_menu_item("Install Meta Export Template...");
+			}
 
 			// Clean up the editor export plugin
 			remove_export_plugin(_meta_toolkit_export_plugin);
@@ -33,4 +55,28 @@ void MetaToolkitEditorPlugin::_notification(uint32_t p_what) {
 
 void MetaToolkitEditorPlugin::_configure_xr_simulator() {
 	_meta_xr_simulator_dialog->show();
+}
+
+void MetaToolkitEditorPlugin::_configure_export_template() {
+	_meta_export_templates_dialog->show();
+}
+
+void MetaToolkitEditorPlugin::_add_plugin_editor_settings() {
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	ERR_FAIL_NULL(editor_interface);
+	Ref<EditorSettings> editor_settings = editor_interface->get_editor_settings();
+	ERR_FAIL_COND(editor_settings.is_null());
+
+	String base_download_url_setting = "xr/meta_toolkit/base_download_url";
+	String base_download_url_default = "https://github.com/godot-sdk-integrations/godot-meta-toolkit/releases/download/";
+	if (!editor_settings->has_setting(base_download_url_setting)) {
+		editor_settings->set_setting(base_download_url_setting, base_download_url_default);
+	}
+
+	editor_settings->set_initial_value(base_download_url_setting, base_download_url_default, false);
+	Dictionary base_download_url_property_info;
+	base_download_url_property_info["name"] = base_download_url_setting;
+	base_download_url_property_info["type"] = Variant::Type::STRING;
+	base_download_url_property_info["hint"] = PROPERTY_HINT_NONE;
+	editor_settings->add_property_info(base_download_url_property_info);
 }

--- a/toolkit/src/main/cpp/export/meta_toolkit_export_plugin.cpp
+++ b/toolkit/src/main/cpp/export/meta_toolkit_export_plugin.cpp
@@ -2,13 +2,20 @@
 
 #include "export/meta_toolkit_export_plugin.h"
 
+#include "util.h"
+
 #include <godot_cpp/classes/editor_export_platform_android.hpp>
 #include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
 
 namespace {
+static const char *TOOLKIT_PREBUILT_DEBUG_TEMPLATE_PATH = "res://addons/godot_meta_toolkit/.build_template/prebuilt/debug/android_debug.apk";
+static const char *TOOLKIT_PREBUILT_RELEASE_TEMPLATE_PATH = "res://addons/godot_meta_toolkit/.build_template/prebuilt/release/android_release.apk";
 static const char *TOOLKIT_BUILD_TEMPLATE_ZIP_PATH = "res://addons/godot_meta_toolkit/.build_template/quest_build_template.zip";
 static const char *TOOLKIT_DEBUG_KEYSTORE_PATH = "res://addons/godot_meta_toolkit/.build_template/keystore/debug.keystore";
 static const char *TOOLKIT_DEBUG_KEYSTORE_PROPERTIES_PATH = "res://addons/godot_meta_toolkit/.build_template/keystore/debug.keystore.properties";
@@ -64,6 +71,22 @@ bool MetaToolkitExportPlugin::_get_bool_option(const godot::String &p_option) co
 	return false;
 }
 
+int MetaToolkitExportPlugin::_get_int_option(const godot::String &p_option, int default_value) const {
+	Variant option_value = get_option(p_option);
+	if (option_value.get_type() == Variant::Type::INT) {
+		return option_value;
+	}
+	return default_value;
+}
+
+bool MetaToolkitExportPlugin::_is_plugin_enabled() const {
+	return _get_bool_option("meta_toolkit/enable_meta_toolkit");
+}
+
+String MetaToolkitExportPlugin::_bool_to_string(bool p_value) const {
+	return p_value ? "true" : "false";
+}
+
 TypedArray<Dictionary> MetaToolkitExportPlugin::_get_export_options(const Ref<godot::EditorExportPlatform> &p_platform) const {
 	TypedArray<Dictionary> export_options;
 	if (!_supports_platform(p_platform)) {
@@ -88,15 +111,27 @@ Dictionary MetaToolkitExportPlugin::_get_export_options_overrides(
 	}
 
 	// Check if this plugin is enabled
-	if (!_get_bool_option("meta_toolkit/enable_meta_toolkit")) {
+	if (!_is_plugin_enabled()) {
 		return overrides;
 	}
 
 	// Gradle build overrides
-	overrides["gradle_build/use_gradle_build"] = true;
 	overrides["gradle_build/export_format"] = 0; // apk
-	overrides["gradle_build/min_sdk"] = "29"; // Android 10
-	overrides["gradle_build/target_sdk"] = "34"; // Android 14
+	bool is_mobile_editor = OS::get_singleton()->has_feature("mobile");
+	if (!is_mobile_editor) {
+		overrides["gradle_build/min_sdk"] = "29"; // Android 10
+		overrides["gradle_build/use_gradle_build"] = true;
+	} else {
+		overrides["gradle_build/compress_native_libraries"] = false;
+	}
+
+	// Check if we have a prebuilt template.
+	if (FileAccess::file_exists(TOOLKIT_PREBUILT_DEBUG_TEMPLATE_PATH)) {
+		overrides["custom_template/debug"] = TOOLKIT_PREBUILT_DEBUG_TEMPLATE_PATH;
+	}
+	if (FileAccess::file_exists(TOOLKIT_PREBUILT_RELEASE_TEMPLATE_PATH)) {
+		overrides["custom_template/release"] = TOOLKIT_PREBUILT_RELEASE_TEMPLATE_PATH;
+	}
 
 	// Check if we have an alternate build template
 	if (FileAccess::file_exists(TOOLKIT_BUILD_TEMPLATE_ZIP_PATH)) {
@@ -143,6 +178,8 @@ Dictionary MetaToolkitExportPlugin::_get_export_options_overrides(
 
 	// Package overrides
 	overrides["package/show_in_android_tv"] = false;
+	overrides["package/show_in_app_library"] = true;
+	overrides["package/show_as_launcher_app"] = false;
 
 	// Screen overrides
 	overrides["screen/immersive_mode"] = true;
@@ -150,6 +187,9 @@ Dictionary MetaToolkitExportPlugin::_get_export_options_overrides(
 	overrides["screen/support_normal"] = true;
 	overrides["screen/support_large"] = true;
 	overrides["screen/support_xlarge"] = true;
+
+	// Gesture overrides
+	overrides["gesture/swipe_to_dismiss"] = false;
 
 	// XR features overrides
 	overrides["xr_features/xr_mode"] = 1; // OpenXR mode
@@ -176,4 +216,631 @@ PackedStringArray MetaToolkitExportPlugin::_get_android_libraries(const Ref<godo
 	}
 
 	return dependencies;
+}
+
+PackedStringArray MetaToolkitExportPlugin::_get_supported_devices() const {
+	PackedStringArray supported_devices;
+
+	if (_get_bool_option("meta_xr_features/quest_1_support")) {
+		supported_devices.append("quest");
+	}
+
+	if (_get_bool_option("meta_xr_features/quest_2_support")) {
+		supported_devices.append("quest2");
+	}
+
+	if (_get_bool_option("meta_xr_features/quest_3_support")) {
+		supported_devices.append("quest3");
+		supported_devices.append("quest3s");
+	}
+
+	if (_get_bool_option("meta_xr_features/quest_pro_support")) {
+		supported_devices.append("questpro");
+	}
+
+	return supported_devices;
+}
+
+void MetaToolkitExportPlugin::_get_manifest_entries(Vector<godot::String> &r_permissions, Vector<MetaToolkitExportPlugin::FeatureInfo> &r_features, Vector<MetadataInfo> &r_metadata) const {
+	// Supported devices
+	const String supported_devices = String("|").join(_get_supported_devices());
+	MetadataInfo supported_devices_metadata = {
+		"com.oculus.supportedDevices",
+		supported_devices
+	};
+	r_metadata.append(supported_devices_metadata);
+
+	// Check for eye tracking.
+	bool eye_tracking_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction");
+	if (eye_tracking_enabled) {
+		r_permissions.append("com.oculus.permission.EYE_TRACKING");
+
+		FeatureInfo eye_tracking_feature = {
+			"oculus.software.eye_tracking",
+			_get_int_option("meta_xr_features/eye_tracking", EYE_TRACKING_OPTIONAL_VALUE) == EYE_TRACKING_REQUIRED_VALUE,
+		};
+		r_features.append(eye_tracking_feature);
+	}
+
+	// Check for face tracking.
+	bool face_tracking_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/face_tracking");
+	if (face_tracking_enabled) {
+		r_permissions.append("com.oculus.permission.FACE_TRACKING");
+
+		FeatureInfo face_tracking_info = {
+			"oculus.software.face_tracking",
+			_get_int_option("meta_xr_features/face_tracking", FACE_TRACKING_OPTIONAL_VALUE) == FACE_TRACKING_REQUIRED_VALUE,
+		};
+		r_features.append(face_tracking_info);
+	}
+
+	// Check for body tracking.
+	bool body_tracking_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/body_tracking");
+	if (body_tracking_enabled) {
+		r_permissions.append("com.oculus.permission.BODY_TRACKING");
+
+		FeatureInfo body_tracking_info = {
+			"com.oculus.software.body_tracking",
+			_get_int_option("meta_xr_features/body_tracking", BODY_TRACKING_OPTIONAL_VALUE) == BODY_TRACKING_REQUIRED_VALUE,
+		};
+		r_features.append(body_tracking_info);
+	}
+
+	// Check for hand tracking.
+	bool hand_tracking_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+	if (hand_tracking_enabled) {
+		r_permissions.append("com.oculus.permission.HAND_TRACKING");
+
+		FeatureInfo hand_tracking_info = {
+			"oculus.software.handtracking",
+			_get_int_option("meta_xr_features/hand_tracking", HAND_TRACKING_OPTIONAL_VALUE) == HAND_TRACKING_REQUIRED_VALUE,
+		};
+		r_features.append(hand_tracking_info);
+
+		MetadataInfo hand_tracking_version_metadata = {
+			"com.oculus.handtracking.version",
+			"V2.0"
+		};
+		r_metadata.append(hand_tracking_version_metadata);
+
+		int hand_tracking_frequency = _get_int_option("meta_xr_features/hand_tracking_frequency", HAND_TRACKING_FREQUENCY_LOW_VALUE);
+		const String hand_tracking_frequency_label = (hand_tracking_frequency == HAND_TRACKING_FREQUENCY_LOW_VALUE) ? "LOW" : "HIGH";
+		MetadataInfo hand_tracking_frequency_metadata = {
+			"com.oculus.handtracking.frequency",
+			hand_tracking_frequency_label
+		};
+		r_metadata.append(hand_tracking_frequency_metadata);
+	}
+
+	// Check for passthrough.
+	bool passthrough_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/passthrough");
+	if (passthrough_enabled) {
+		FeatureInfo passthrough_info = {
+			"com.oculus.feature.PASSTHROUGH",
+			_get_int_option("meta_xr_features/passthrough", PASSTHROUGH_OPTIONAL_VALUE) == PASSTHROUGH_REQUIRED_VALUE,
+		};
+		r_features.append(passthrough_info);
+	}
+
+	// Check for render model.
+	bool render_model_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/render_model");
+	if (render_model_enabled) {
+		r_permissions.append("com.oculus.permission.RENDER_MODEL");
+
+		FeatureInfo render_model_info = {
+			"com.oculus.feature.RENDER_MODEL",
+			_get_int_option("meta_xr_features/render_model", RENDER_MODEL_OPTIONAL_VALUE) == RENDER_MODEL_REQUIRED_VALUE,
+		};
+		r_features.append(render_model_info);
+	}
+
+	// Check for anchor api.
+	bool use_anchor_api = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/anchor_api");
+	if (use_anchor_api) {
+		r_permissions.append("com.oculus.permission.USE_ANCHOR_API");
+	}
+
+	// Check for anchor sharing.
+	bool use_anchor_sharing = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/anchor_sharing");
+	if (use_anchor_sharing) {
+		r_permissions.append("com.oculus.permission.IMPORT_EXPORT_IOT_MAP_DATA");
+	}
+
+	// Check for scene api.
+	bool use_scene_api = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/scene_api");
+	bool use_environment_depth = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/environment_depth");
+	if (use_scene_api || use_environment_depth) {
+		r_permissions.append("com.oculus.permission.USE_SCENE");
+	}
+
+	// Check for overlay keyboard.
+	bool use_overlay_keyboard_option = _get_bool_option("meta_xr_features/use_overlay_keyboard");
+	if (use_overlay_keyboard_option) {
+		FeatureInfo overlay_keyboard_info = {
+			"oculus.software.overlay_keyboard",
+			true
+		};
+		r_features.append(overlay_keyboard_info);
+	}
+
+	// Check for experimental features.
+	bool use_experimental_features = _get_bool_option("meta_xr_features/use_experimental_features");
+	if (use_experimental_features) {
+		FeatureInfo experimental_feature_info = {
+			"com.oculus.experimental.enabled",
+			true
+		};
+		r_features.append(experimental_feature_info);
+	}
+
+	// Check for boundary mode
+	int boundary_mode = _get_int_option("meta_xr_features/boundary_mode", BOUNDARY_ENABLED_VALUE);
+	if (boundary_mode == BOUNDARY_DISABLED_VALUE) {
+		FeatureInfo boundary_mode_info = {
+			"com.oculus.feature.BOUNDARYLESS_APP",
+			true
+		};
+		r_features.append(boundary_mode_info);
+	}
+
+	// Check for instant splash screen
+	bool instant_splash_screen = _get_bool_option("meta_xr_features/instant_splash_screen");
+	if (instant_splash_screen) {
+		MetadataInfo instant_splash_screen_metadata = {
+			"com.oculus.ossplash",
+			"true"
+		};
+		r_metadata.append(instant_splash_screen_metadata);
+	}
+
+	// Check for splash screen in passthrough
+	if ((int)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/environment_blend_mode") != XRInterface::XR_ENV_BLEND_MODE_OPAQUE) {
+		MetadataInfo contextual_passthrough_metadata = {
+			"com.oculus.ossplash.background",
+			"passthrough-contextual"
+		};
+		r_metadata.append(contextual_passthrough_metadata);
+	}
+}
+
+PackedByteArray MetaToolkitExportPlugin::_update_android_prebuilt_manifest(const Ref<godot::EditorExportPlatform> &p_platform, const godot::PackedByteArray &p_manifest_data) const {
+	PackedByteArray result;
+	if (!_supports_platform(p_platform) || !_is_plugin_enabled() || p_manifest_data.is_empty()) {
+		return result;
+	}
+
+	Vector<uint8_t> manifest_buffer;
+	manifest_buffer.resize(p_manifest_data.size());
+	memcpy(manifest_buffer.ptrw(), p_manifest_data.ptr(), p_manifest_data.size());
+
+	// Leaving the unused types commented because looking these constants up
+	// again later would be annoying
+	// const int CHUNK_AXML_FILE = 0x00080003;
+	// const int CHUNK_RESOURCEIDS = 0x00080180;
+	const int CHUNK_STRINGS = 0x001C0001;
+	// const int CHUNK_XML_END_NAMESPACE = 0x00100101;
+	const int CHUNK_XML_END_TAG = 0x00100103;
+	// const int CHUNK_XML_START_NAMESPACE = 0x00100100;
+	const int CHUNK_XML_START_TAG = 0x00100102;
+	// const int CHUNK_XML_TEXT = 0x00100104;
+	const int UTF8_FLAG = 0x00000100;
+
+	Vector<String> string_table;
+
+	uint32_t ofs = 8;
+
+	uint32_t string_count = 0;
+	uint32_t string_flags = 0;
+	uint32_t string_data_offset = 0;
+
+	uint32_t string_table_begins = 0;
+	uint32_t string_table_ends = 0;
+	Vector<uint8_t> stable_extra;
+
+	Vector<String> permissions;
+	Vector<FeatureInfo> features;
+	Vector<MetadataInfo> metadata;
+	_get_manifest_entries(permissions, features, metadata);
+
+	while (ofs < (uint32_t)manifest_buffer.size()) {
+		uint32_t chunk = decode_uint32(&manifest_buffer[ofs]);
+		uint32_t size = decode_uint32(&manifest_buffer[ofs + 4]);
+
+		switch (chunk) {
+			case CHUNK_STRINGS: {
+				int iofs = ofs + 8;
+
+				string_count = decode_uint32(&manifest_buffer[iofs]);
+				string_flags = decode_uint32(&manifest_buffer[iofs + 8]);
+				string_data_offset = decode_uint32(&manifest_buffer[iofs + 12]);
+
+				uint32_t st_offset = iofs + 20;
+				string_table.resize(string_count);
+				uint32_t string_end = 0;
+
+				string_table_begins = st_offset;
+
+				for (uint32_t i = 0; i < string_count; i++) {
+					uint32_t string_at = decode_uint32(&manifest_buffer[st_offset + i * 4]);
+					string_at += st_offset + string_count * 4;
+
+					ERR_FAIL_COND_V_MSG(string_flags & UTF8_FLAG, result, "Unimplemented, can't read UTF-8 string table.");
+
+					if (string_flags & UTF8_FLAG) {
+					} else {
+						uint32_t len = decode_uint16(&manifest_buffer[string_at]);
+						Vector<char32_t> ucstring;
+						ucstring.resize(len + 1);
+						for (uint32_t j = 0; j < len; j++) {
+							uint16_t c = decode_uint16(&manifest_buffer[string_at + 2 + 2 * j]);
+							ucstring.write[j] = c;
+						}
+						string_end = MAX(string_at + 2 + 2 * len, string_end);
+						ucstring.write[len] = 0;
+						string_table.write[i] = ucstring.ptr();
+					}
+				}
+
+				for (uint32_t i = string_end; i < (ofs + size); i++) {
+					stable_extra.push_back(manifest_buffer[i]);
+				}
+
+				string_table_ends = ofs + size;
+
+			} break;
+			case CHUNK_XML_END_TAG: {
+				int iofs = ofs + 8;
+				uint32_t name = decode_uint32(&manifest_buffer[iofs + 12]);
+				String tname = string_table[name];
+
+				if (tname == "manifest" || tname == "application") {
+					// save manifest ending so we can restore it
+					Vector<uint8_t> manifest_end;
+					uint32_t manifest_cur_size = manifest_buffer.size();
+
+					manifest_end.resize(manifest_buffer.size() - ofs);
+					memcpy(manifest_end.ptrw(), &manifest_buffer[ofs], manifest_end.size());
+
+					int32_t attr_name_string = string_table.find("name");
+					ERR_FAIL_COND_V_MSG(attr_name_string == -1, result, "Template does not have 'name' attribute.");
+
+					int32_t ns_android_string = string_table.find("http://schemas.android.com/apk/res/android");
+					if (ns_android_string == -1) {
+						string_table.push_back("http://schemas.android.com/apk/res/android");
+						ns_android_string = string_table.size() - 1;
+					}
+
+					if (tname == "manifest") {
+						// Updating manifest features
+						int32_t attr_uses_feature_string = string_table.find("uses-feature");
+						if (attr_uses_feature_string == -1) {
+							string_table.push_back("uses-feature");
+							attr_uses_feature_string = string_table.size() - 1;
+						}
+
+						int32_t attr_required_string = string_table.find("required");
+						if (attr_required_string == -1) {
+							string_table.push_back("required");
+							attr_required_string = string_table.size() - 1;
+						}
+
+						for (int i = 0; i < features.size(); i++) {
+							const String &feature_name = features[i].name;
+							bool feature_required = features[i].required;
+							String feature_version = features[i].version;
+							bool has_version_attribute = !feature_version.is_empty();
+
+							UtilityFunctions::print_verbose("Adding feature " + feature_name);
+
+							int32_t feature_string = string_table.find(feature_name);
+							if (feature_string == -1) {
+								string_table.push_back(feature_name);
+								feature_string = string_table.size() - 1;
+							}
+
+							String required_value_string = feature_required ? "true" : "false";
+							int32_t required_value = string_table.find(required_value_string);
+							if (required_value == -1) {
+								string_table.push_back(required_value_string);
+								required_value = string_table.size() - 1;
+							}
+
+							int32_t attr_version_string = -1;
+							int32_t version_value = -1;
+							int tag_size;
+							int attr_count;
+							if (has_version_attribute) {
+								attr_version_string = string_table.find("version");
+								if (attr_version_string == -1) {
+									string_table.push_back("version");
+									attr_version_string = string_table.size() - 1;
+								}
+
+								version_value = string_table.find(feature_version);
+								if (version_value == -1) {
+									string_table.push_back(feature_version);
+									version_value = string_table.size() - 1;
+								}
+
+								tag_size = 96; // node and three attrs + end node
+								attr_count = 3;
+							} else {
+								tag_size = 76; // node and two attrs + end node
+								attr_count = 2;
+							}
+							manifest_cur_size += tag_size + 24;
+							manifest_buffer.resize(manifest_cur_size);
+
+							// start tag
+							encode_uint16(0x102, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(tag_size, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_feature_string, &manifest_buffer.write[ofs + 20]); // name
+							encode_uint16(20, &manifest_buffer.write[ofs + 24]); // attr_start
+							encode_uint16(20, &manifest_buffer.write[ofs + 26]); // attr_size
+							encode_uint16(attr_count, &manifest_buffer.write[ofs + 28]); // num_attrs
+							encode_uint16(0, &manifest_buffer.write[ofs + 30]); // id_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 32]); // class_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 34]); // style_index
+
+							// android:name attribute
+							encode_uint32(ns_android_string, &manifest_buffer.write[ofs + 36]); // ns
+							encode_uint32(attr_name_string, &manifest_buffer.write[ofs + 40]); // 'name'
+							encode_uint32(feature_string, &manifest_buffer.write[ofs + 44]); // raw_value
+							encode_uint16(8, &manifest_buffer.write[ofs + 48]); // typedvalue_size
+							manifest_buffer.write[ofs + 50] = 0; // typedvalue_always0
+							manifest_buffer.write[ofs + 51] = 0x03; // typedvalue_type (string)
+							encode_uint32(feature_string, &manifest_buffer.write[ofs + 52]); // typedvalue reference
+
+							// android:required attribute
+							encode_uint32(ns_android_string, &manifest_buffer.write[ofs + 56]); // ns
+							encode_uint32(attr_required_string, &manifest_buffer.write[ofs + 60]); // 'name'
+							encode_uint32(required_value, &manifest_buffer.write[ofs + 64]); // raw_value
+							encode_uint16(8, &manifest_buffer.write[ofs + 68]); // typedvalue_size
+							manifest_buffer.write[ofs + 70] = 0; // typedvalue_always0
+							manifest_buffer.write[ofs + 71] = 0x03; // typedvalue_type (string)
+							encode_uint32(required_value, &manifest_buffer.write[ofs + 72]); // typedvalue reference
+
+							ofs += 76;
+
+							if (has_version_attribute) {
+								// android:version attribute
+								encode_uint32(ns_android_string, &manifest_buffer.write[ofs]); // ns
+								encode_uint32(attr_version_string, &manifest_buffer.write[ofs + 4]); // 'name'
+								encode_uint32(version_value, &manifest_buffer.write[ofs + 8]); // raw_value
+								encode_uint16(8, &manifest_buffer.write[ofs + 12]); // typedvalue_size
+								manifest_buffer.write[ofs + 14] = 0; // typedvalue_always0
+								manifest_buffer.write[ofs + 15] = 0x03; // typedvalue_type (string)
+								encode_uint32(version_value, &manifest_buffer.write[ofs + 16]); // typedvalue reference
+
+								ofs += 20;
+							}
+
+							// end tag
+							encode_uint16(0x103, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(24, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_feature_string, &manifest_buffer.write[ofs + 20]); // name
+
+							ofs += 24;
+						}
+
+						// Updating manifest permissions
+						int32_t attr_uses_permission_string = string_table.find("uses-permission");
+						if (attr_uses_permission_string == -1) {
+							string_table.push_back("uses-permission");
+							attr_uses_permission_string = string_table.size() - 1;
+						}
+
+						for (int i = 0; i < permissions.size(); ++i) {
+							UtilityFunctions::print_verbose("Adding permission " + permissions[i]);
+
+							manifest_cur_size += 56 + 24; // node + end node
+							manifest_buffer.resize(manifest_cur_size);
+
+							// Add permission to the string pool
+							int32_t perm_string = string_table.find(permissions[i]);
+							if (perm_string == -1) {
+								string_table.push_back(permissions[i]);
+								perm_string = string_table.size() - 1;
+							}
+
+							// start tag
+							encode_uint16(0x102, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(56, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_permission_string, &manifest_buffer.write[ofs + 20]); // name
+							encode_uint16(20, &manifest_buffer.write[ofs + 24]); // attr_start
+							encode_uint16(20, &manifest_buffer.write[ofs + 26]); // attr_size
+							encode_uint16(1, &manifest_buffer.write[ofs + 28]); // num_attrs
+							encode_uint16(0, &manifest_buffer.write[ofs + 30]); // id_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 32]); // class_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 34]); // style_index
+
+							// attribute
+							encode_uint32(ns_android_string, &manifest_buffer.write[ofs + 36]); // ns
+							encode_uint32(attr_name_string, &manifest_buffer.write[ofs + 40]); // 'name'
+							encode_uint32(perm_string, &manifest_buffer.write[ofs + 44]); // raw_value
+							encode_uint16(8, &manifest_buffer.write[ofs + 48]); // typedvalue_size
+							manifest_buffer.write[ofs + 50] = 0; // typedvalue_always0
+							manifest_buffer.write[ofs + 51] = 0x03; // typedvalue_type (string)
+							encode_uint32(perm_string, &manifest_buffer.write[ofs + 52]); // typedvalue reference
+
+							ofs += 56;
+
+							// end tag
+							encode_uint16(0x103, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(24, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_permission_string, &manifest_buffer.write[ofs + 20]); // name
+
+							ofs += 24;
+						}
+					}
+
+					if (tname == "application") {
+						// Updating application meta-data
+						int32_t attr_meta_data_string = string_table.find("meta-data");
+						if (attr_meta_data_string == -1) {
+							string_table.push_back("meta-data");
+							attr_meta_data_string = string_table.size() - 1;
+						}
+
+						int32_t attr_value_string = string_table.find("value");
+						if (attr_value_string == -1) {
+							string_table.push_back("value");
+							attr_value_string = string_table.size() - 1;
+						}
+
+						for (int i = 0; i < metadata.size(); i++) {
+							String meta_data_name = metadata[i].name;
+							String meta_data_value = metadata[i].value;
+
+							UtilityFunctions::print_verbose("Adding application metadata " + meta_data_name);
+
+							int32_t meta_data_name_string = string_table.find(meta_data_name);
+							if (meta_data_name_string == -1) {
+								string_table.push_back(meta_data_name);
+								meta_data_name_string = string_table.size() - 1;
+							}
+
+							int32_t meta_data_value_string = string_table.find(meta_data_value);
+							if (meta_data_value_string == -1) {
+								string_table.push_back(meta_data_value);
+								meta_data_value_string = string_table.size() - 1;
+							}
+
+							int tag_size = 76; // node and two attrs + end node
+							int attr_count = 2;
+							manifest_cur_size += tag_size + 24;
+							manifest_buffer.resize(manifest_cur_size);
+
+							// start tag
+							encode_uint16(0x102, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(tag_size, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_meta_data_string, &manifest_buffer.write[ofs + 20]); // name
+							encode_uint16(20, &manifest_buffer.write[ofs + 24]); // attr_start
+							encode_uint16(20, &manifest_buffer.write[ofs + 26]); // attr_size
+							encode_uint16(attr_count, &manifest_buffer.write[ofs + 28]); // num_attrs
+							encode_uint16(0, &manifest_buffer.write[ofs + 30]); // id_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 32]); // class_index
+							encode_uint16(0, &manifest_buffer.write[ofs + 34]); // style_index
+
+							// android:name attribute
+							encode_uint32(ns_android_string, &manifest_buffer.write[ofs + 36]); // ns
+							encode_uint32(attr_name_string, &manifest_buffer.write[ofs + 40]); // 'name'
+							encode_uint32(meta_data_name_string, &manifest_buffer.write[ofs + 44]); // raw_value
+							encode_uint16(8, &manifest_buffer.write[ofs + 48]); // typedvalue_size
+							manifest_buffer.write[ofs + 50] = 0; // typedvalue_always0
+							manifest_buffer.write[ofs + 51] = 0x03; // typedvalue_type (string)
+							encode_uint32(meta_data_name_string, &manifest_buffer.write[ofs + 52]); // typedvalue reference
+
+							// android:value attribute
+							encode_uint32(ns_android_string, &manifest_buffer.write[ofs + 56]); // ns
+							encode_uint32(attr_value_string, &manifest_buffer.write[ofs + 60]); // 'value'
+							encode_uint32(meta_data_value_string, &manifest_buffer.write[ofs + 64]); // raw_value
+							encode_uint16(8, &manifest_buffer.write[ofs + 68]); // typedvalue_size
+							manifest_buffer.write[ofs + 70] = 0; // typedvalue_always0
+							manifest_buffer.write[ofs + 71] = 0x03; // typedvalue_type (string)
+							encode_uint32(meta_data_value_string, &manifest_buffer.write[ofs + 72]); // typedvalue reference
+
+							ofs += 76;
+
+							// end tag
+							encode_uint16(0x103, &manifest_buffer.write[ofs]); // type
+							encode_uint16(16, &manifest_buffer.write[ofs + 2]); // headersize
+							encode_uint32(24, &manifest_buffer.write[ofs + 4]); // size
+							encode_uint32(0, &manifest_buffer.write[ofs + 8]); // lineno
+							encode_uint32(-1, &manifest_buffer.write[ofs + 12]); // comment
+							encode_uint32(-1, &manifest_buffer.write[ofs + 16]); // ns
+							encode_uint32(attr_meta_data_string, &manifest_buffer.write[ofs + 20]); // name
+
+							ofs += 24;
+						}
+					}
+
+					// copy footer back in
+					memcpy(&manifest_buffer.write[ofs], manifest_end.ptr(), manifest_end.size());
+				}
+			} break;
+		}
+
+		ofs += size;
+	}
+
+	// Create new android manifest binary.
+	Vector<uint8_t> ret;
+	ret.resize(string_table_begins + string_table.size() * 4);
+
+	for (uint32_t i = 0; i < string_table_begins; i++) {
+		ret.write[i] = manifest_buffer[i];
+	}
+
+	ofs = 0;
+	for (int i = 0; i < string_table.size(); i++) {
+		encode_uint32(ofs, &ret.write[string_table_begins + i * 4]);
+		ofs += string_table[i].length() * 2 + 2 + 2;
+	}
+
+	ret.resize(ret.size() + ofs);
+	string_data_offset = ret.size() - ofs;
+	uint8_t *chars = &ret.write[string_data_offset];
+	for (int i = 0; i < string_table.size(); i++) {
+		String s = string_table[i];
+		encode_uint16(s.length(), chars);
+		chars += 2;
+		for (int j = 0; j < s.length(); j++) {
+			encode_uint16(s[j], chars);
+			chars += 2;
+		}
+		encode_uint16(0, chars);
+		chars += 2;
+	}
+
+	for (int i = 0; i < stable_extra.size(); i++) {
+		ret.push_back(stable_extra[i]);
+	}
+
+	//pad
+	while (ret.size() % 4) {
+		ret.push_back(0);
+	}
+
+	uint32_t new_stable_end = ret.size();
+
+	uint32_t extra = (manifest_buffer.size() - string_table_ends);
+	ret.resize(new_stable_end + extra);
+	for (uint32_t i = 0; i < extra; i++) {
+		ret.write[new_stable_end + i] = manifest_buffer[string_table_ends + i];
+	}
+
+	while (ret.size() % 4) {
+		ret.push_back(0);
+	}
+	encode_uint32(ret.size(), &ret.write[4]); //update new file size
+
+	encode_uint32(new_stable_end - 8, &ret.write[12]); //update new string table size
+	encode_uint32(string_table.size(), &ret.write[16]); //update new number of strings
+	encode_uint32(string_data_offset - 8, &ret.write[28]); //update new string data offset
+
+	result.resize(ret.size());
+	memcpy(result.ptrw(), ret.ptr(), ret.size());
+
+	return result;
 }

--- a/toolkit/src/main/cpp/include/editor/meta_export_template_dialog.h
+++ b/toolkit/src/main/cpp/include/editor/meta_export_template_dialog.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2024-present Meta Platforms, Inc. and affiliates. All rights reserved.
+
+#pragma once
+
+#include <godot_cpp/classes/accept_dialog.hpp>
+
+namespace godot {
+class Label;
+class ProgressBar;
+class Button;
+class HTTPRequest;
+} //namespace godot
+
+using namespace godot;
+
+class MetaExportTemplateDialog : public AcceptDialog {
+	GDCLASS(MetaExportTemplateDialog, AcceptDialog);
+
+	Label *message = nullptr;
+	ProgressBar *download_progress_bar = nullptr;
+	Button *download_button = nullptr;
+	HTTPRequest *download_request = nullptr;
+
+	float update_countdown = 0.0f;
+
+	bool is_downloading_template = false;
+
+	void _update();
+
+	void _download_template();
+	void _set_current_progress_value(float p_value, const String &p_status);
+	void _set_current_progress_status(const String &p_status, bool p_error = false);
+	void _download_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
+	bool _humanize_http_status(HTTPRequest *p_request, String &r_status, int &r_downloaded_bytes, int &r_total_bytes);
+
+protected:
+	static void _bind_methods();
+
+	void _notification(uint32_t p_what);
+
+public:
+	void show();
+
+	MetaExportTemplateDialog();
+};

--- a/toolkit/src/main/cpp/include/editor/meta_toolkit_editor_plugin.h
+++ b/toolkit/src/main/cpp/include/editor/meta_toolkit_editor_plugin.h
@@ -8,14 +8,18 @@
 
 using namespace godot;
 class MetaXRSimulatorDialog;
+class MetaExportTemplateDialog;
 
 class MetaToolkitEditorPlugin : public EditorPlugin {
 	GDCLASS(MetaToolkitEditorPlugin, EditorPlugin);
 
 	Ref<MetaToolkitExportPlugin> _meta_toolkit_export_plugin;
 	MetaXRSimulatorDialog *_meta_xr_simulator_dialog = nullptr;
+	MetaExportTemplateDialog *_meta_export_templates_dialog = nullptr;
 
 	void _configure_xr_simulator();
+	void _configure_export_template();
+	void _add_plugin_editor_settings();
 
 protected:
 	static void _bind_methods();

--- a/toolkit/src/main/cpp/include/export/meta_toolkit_export_plugin.h
+++ b/toolkit/src/main/cpp/include/export/meta_toolkit_export_plugin.h
@@ -10,6 +10,30 @@ using namespace godot;
 class MetaToolkitExportPlugin : public EditorExportPlugin {
 	GDCLASS(MetaToolkitExportPlugin, EditorExportPlugin)
 
+	static const int EYE_TRACKING_OPTIONAL_VALUE = 1;
+	static const int EYE_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int FACE_TRACKING_OPTIONAL_VALUE = 1;
+	static const int FACE_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int BODY_TRACKING_OPTIONAL_VALUE = 1;
+	static const int BODY_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int PASSTHROUGH_OPTIONAL_VALUE = 1;
+	static const int PASSTHROUGH_REQUIRED_VALUE = 2;
+
+	static const int RENDER_MODEL_OPTIONAL_VALUE = 1;
+	static const int RENDER_MODEL_REQUIRED_VALUE = 2;
+
+	static const int HAND_TRACKING_OPTIONAL_VALUE = 1;
+	static const int HAND_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
+	static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
+
+	static const int BOUNDARY_ENABLED_VALUE = 0;
+	static const int BOUNDARY_DISABLED_VALUE = 1;
+
 public:
 	MetaToolkitExportPlugin();
 
@@ -27,10 +51,23 @@ public:
 
 	bool _supports_platform(const Ref<EditorExportPlatform> &p_platform) const override;
 
+	PackedByteArray _update_android_prebuilt_manifest(const Ref<EditorExportPlatform> &p_platform, const PackedByteArray &updated_manifest) const override;
+
 protected:
 	static void _bind_methods();
 
 private:
+	struct FeatureInfo {
+		String name;
+		bool required;
+		String version = "";
+	};
+
+	struct MetadataInfo {
+		String name;
+		String value;
+	};
+
 	static Dictionary _generate_export_option(const String &p_name, const String &p_class_name,
 			Variant::Type p_type,
 			PropertyHint p_property_hint,
@@ -40,6 +77,16 @@ private:
 			bool p_update_visibility);
 
 	bool _get_bool_option(const String &p_option) const;
+
+	int _get_int_option(const String &p_option, int default_value) const;
+
+	String _bool_to_string(bool p_value) const;
+
+	bool _is_plugin_enabled() const;
+
+	void _get_manifest_entries(Vector<String> &r_permissions, Vector<FeatureInfo> &r_features, Vector<MetadataInfo> &r_metadata) const;
+
+	PackedStringArray _get_supported_devices() const;
 
 	Dictionary _enable_meta_toolkit_option;
 };

--- a/toolkit/src/main/cpp/include/platform_sdk/meta_platform_sdk_request.h
+++ b/toolkit/src/main/cpp/include/platform_sdk/meta_platform_sdk_request.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 #include <OVR_Types.h>
-#endif // ANDROID_ENABLED
+#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 
 #include <godot_cpp/classes/ref.hpp>
 
@@ -15,20 +15,20 @@ class MetaPlatformSDK_Request : public RefCounted {
 
 	friend class MetaPlatformSDK;
 
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	ovrRequest id = 0;
-#endif // ANDROID_ENABLED
+#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 
 protected:
 	static void _bind_methods();
 
 public:
 	inline uint64_t get_id() {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 		return id;
 #else
 		return 0;
-#endif // ANDROID_ENABLED
+#endif // defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	}
 
 	MetaPlatformSDK_Request();

--- a/toolkit/src/main/cpp/include/util.h
+++ b/toolkit/src/main/cpp/include/util.h
@@ -17,3 +17,49 @@ struct CharStringList {
 		}
 	}
 };
+
+static inline unsigned int encode_uint16(uint16_t p_uint, uint8_t *p_arr) {
+	for (int i = 0; i < 2; i++) {
+		*p_arr = p_uint & 0xFF;
+		p_arr++;
+		p_uint >>= 8;
+	}
+
+	return sizeof(uint16_t);
+}
+
+static inline unsigned int encode_uint32(uint32_t p_uint, uint8_t *p_arr) {
+	for (int i = 0; i < 4; i++) {
+		*p_arr = p_uint & 0xFF;
+		p_arr++;
+		p_uint >>= 8;
+	}
+
+	return sizeof(uint32_t);
+}
+
+static inline uint32_t decode_uint32(const uint8_t *p_arr) {
+	uint32_t u = 0;
+
+	for (int i = 0; i < 4; i++) {
+		uint32_t b = *p_arr;
+		b <<= (i * 8);
+		u |= b;
+		p_arr++;
+	}
+
+	return u;
+}
+
+static inline uint16_t decode_uint16(const uint8_t *p_arr) {
+	uint16_t u = 0;
+
+	for (int i = 0; i < 2; i++) {
+		uint16_t b = *p_arr;
+		b <<= (i * 8);
+		u |= b;
+		p_arr++;
+	}
+
+	return u;
+}

--- a/toolkit/src/main/cpp/include/version.h
+++ b/toolkit/src/main/cpp/include/version.h
@@ -1,0 +1,5 @@
+// Copyright (c) 2024-present Meta Platforms, Inc. and affiliates. All rights reserved.
+
+#pragma once
+
+#define GODOT_META_TOOLKIT_VERSION "1.0.4-stable"

--- a/toolkit/src/main/cpp/platform_sdk/meta_platform_sdk.cpp
+++ b/toolkit/src/main/cpp/platform_sdk/meta_platform_sdk.cpp
@@ -19,7 +19,7 @@
 #include "platform_sdk/meta_platform_sdk_message.h"
 #include "platform_sdk/meta_platform_sdk_packet.h"
 
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 #include <OVR_Platform.h>
 #include <jni.h>
 
@@ -28,7 +28,7 @@ static jobject jactivity = nullptr;
 #endif
 
 MetaPlatformSDK::PlatformInitializeResult MetaPlatformSDK::initialize_platform(const String &p_app_id, const Dictionary &p_options) {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	ERR_FAIL_NULL_V(jni_env, PLATFORM_INITIALIZE_UNINITIALIZED);
 	ERR_FAIL_NULL_V(jactivity, PLATFORM_INITIALIZE_UNINITIALIZED);
 
@@ -64,7 +64,7 @@ MetaPlatformSDK::PlatformInitializeResult MetaPlatformSDK::initialize_platform(c
 }
 
 Ref<MetaPlatformSDK_Request> MetaPlatformSDK::initialize_platform_async(const String &p_app_id) {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	ERR_FAIL_NULL_V(jni_env, Ref<MetaPlatformSDK_Request>());
 	ERR_FAIL_NULL_V(jactivity, Ref<MetaPlatformSDK_Request>());
 
@@ -81,7 +81,7 @@ Ref<MetaPlatformSDK_Request> MetaPlatformSDK::initialize_platform_async(const St
 #endif
 }
 
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 extern "C" {
 JNIEXPORT void JNICALL Java_com_meta_w4_godot_toolkit_GodotMetaToolkit_initPlatformSDK(JNIEnv *p_env, jobject p_obj, jobject p_activity) {
 	jni_env = p_env;
@@ -141,7 +141,7 @@ void MetaPlatformSDK::_process_messages() {
  */
 
 uint64_t MetaPlatformSDK_Message::get_request_id() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	return ovr_Message_GetRequestID(handle);
 #else
 	return 0;
@@ -149,7 +149,7 @@ uint64_t MetaPlatformSDK_Message::get_request_id() const {
 }
 
 bool MetaPlatformSDK_Message::is_notification() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	return ovrMessageType_IsNotification((ovrMessageType)type);
 #else
 	return 0;
@@ -157,7 +157,7 @@ bool MetaPlatformSDK_Message::is_notification() const {
 }
 
 uint64_t MetaPlatformSDK_HttpTransferUpdate::get_id() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	return ovr_HttpTransferUpdate_GetID(handle);
 #else
 	return 0;
@@ -165,7 +165,7 @@ uint64_t MetaPlatformSDK_HttpTransferUpdate::get_id() const {
 }
 
 PackedByteArray MetaPlatformSDK_ChallengeEntry::get_extra_data() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	PackedByteArray result;
 
 	const char *data = ovr_ChallengeEntry_GetExtraData(handle);
@@ -184,7 +184,7 @@ PackedByteArray MetaPlatformSDK_ChallengeEntry::get_extra_data() const {
 }
 
 PackedByteArray MetaPlatformSDK_LeaderboardEntry::get_extra_data() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	PackedByteArray result;
 
 	const char *data = ovr_LeaderboardEntry_GetExtraData(handle);
@@ -203,7 +203,7 @@ PackedByteArray MetaPlatformSDK_LeaderboardEntry::get_extra_data() const {
 }
 
 PackedByteArray MetaPlatformSDK_HttpTransferUpdate::get_bytes() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	PackedByteArray result;
 
 	const void *data = ovr_HttpTransferUpdate_GetBytes(handle);
@@ -222,7 +222,7 @@ PackedByteArray MetaPlatformSDK_HttpTransferUpdate::get_bytes() const {
 }
 
 PackedByteArray MetaPlatformSDK_Packet::get_bytes() const {
-#ifdef ANDROID_ENABLED
+#if defined(ANDROID_ENABLED) && !defined(TOOLS_ENABLED)
 	PackedByteArray result;
 
 	const void *data = ovr_Packet_GetBytes(handle);

--- a/toolkit/src/main/cpp/register_types.cpp
+++ b/toolkit/src/main/cpp/register_types.cpp
@@ -4,6 +4,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 
+#include "editor/meta_export_template_dialog.h"
 #include "editor/meta_toolkit_editor_plugin.h"
 #include "editor/meta_xr_simulator_dialog.h"
 #include "export/meta_toolkit_export_plugin.h"
@@ -25,6 +26,7 @@ void initialize_toolkit_module(ModuleInitializationLevel p_level) {
 		case godot::MODULE_INITIALIZATION_LEVEL_EDITOR: {
 			GDREGISTER_INTERNAL_CLASS(MetaToolkitExportPlugin);
 			GDREGISTER_INTERNAL_CLASS(MetaXRSimulatorDialog);
+			GDREGISTER_INTERNAL_CLASS(MetaExportTemplateDialog);
 			GDREGISTER_INTERNAL_CLASS(MetaToolkitEditorPlugin);
 			EditorPlugins::add_by_type<MetaToolkitEditorPlugin>();
 		} break;


### PR DESCRIPTION
This PR builds on top of the work in #15 

For ease of review I've kept commits separate, including a commit that runs `.clang-format` on all of the c++ files. Some of the updates / additions to Fredia's work:

- Updated the export process to check the new vendor plugin project settings.
- `generatePrebuiltApks` now serves as a standalone task, it won't be run when building the plugin.
	- To run `generatePrebuiltApks` it needs to be pointed to a godot directory with `-PgodotDir=path/to/godot`
	- This will create a `meta-export-template.zip` file in the project root, with the idea that we'll host them here in releases of the Godot Meta Toolkit.
	- I've removed the godot submodule since it's now longer needed.
- Added an editor tool that downloads/installs the export the prebuilt apks.
	- Download url is created form a new base url editor setting (default pointing towards this github repo) and I've added a `GODOT_META_TOOLKIT_VERSION` define in a new file `version.h`.