### PR TITLE
Update `CHANGES.md` for the 1.0.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change history for the Godot Meta Toolkit plugin
 
+## 1.0.3
+- Modernize class registration
+- Fix clang format issues
+- Windows: Convert forward slashes from file dialog to backslashes for Meta XR simulator
+- Update for Meta Platform SDK v77
+
 ## 1.0.2
 - Include API documentation in the editor
 - Update for Meta Platform SDK v72


### PR DESCRIPTION
I think we're about ready for another release!

The changelog entries are based on `git log --oneline 1.0.2-stable..`