### PR TITLE
Update XR Sim link in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
 /.vscode/
+/.cache/
 .DS_Store
 /build
 /captures
@@ -17,6 +18,7 @@
 local.properties
 /thirdparty/ovr_platform_sdk/
 /toolkit/src/gen/
+compile_commands.json
 
 # Binaries
 *.o

--- a/docs/manual/xr_simulator.rst
+++ b/docs/manual/xr_simulator.rst
@@ -3,7 +3,7 @@
 XR Simulator
 ============
 
-The `Meta XR Simulator <https://developers.meta.com/horizon/downloads/package/meta-xr-simulator>`_ allows developers to test XR applications on their desktop computer (Windows or MacOS),
+The `Meta XR Simulator <https://developers.meta.com/horizon/documentation/native/xrsim-intro/>`_ allows developers to test XR applications on their desktop computer (Windows or MacOS),
 leading to faster iteration, because the app doesn't need to be deployed to the headset, and the developer doesn't need to constantly put the headset on and off.
 
 Godot can be configured to launch the Meta XR Simulator when you run your game, and the Godot Meta Toolkit includes a tool to help you with that configuration!
@@ -11,7 +11,7 @@ Godot can be configured to launch the Meta XR Simulator when you run your game, 
 Step-by-step instructions
 -------------------------
 
-1. Download the `Meta XR Simulator <https://developers.meta.com/horizon/downloads/package/meta-xr-simulator>`_ and extract it somewhere on your computer.
+1. Download the `Meta XR Simulator <https://developers.meta.com/horizon/documentation/native/xrsim-intro/>`_ and extract it somewhere on your computer.
 
 2. In the Godot editor, click **Project** -> **Tools** -> **Configure Meta XR Simulator...**
 

--- a/toolkit/src/main/cpp/editor/meta_xr_simulator_dialog.cpp
+++ b/toolkit/src/main/cpp/editor/meta_xr_simulator_dialog.cpp
@@ -21,7 +21,7 @@ static const char *META_SIMULATOR_RUNTIME_NAME = "Meta XR Simulator";
 static const char *META_SIMULATOR_INSTRUCTIONS =
 		"In order to allow Godot to run the Meta XR Simulator:\n\n"
 		"[ol]\n"
-		"  Download the Meta XR Simulator using the [url=https://developer.oculus.com/meta-quest-developer-hub]Meta Quest Developer Hub[/url] or [url=https://developer.oculus.com/downloads/package/meta-xr-simulator/]download it directly[/url].\n"
+		"  Download the Meta XR Simulator using the [url=https://developer.oculus.com/meta-quest-developer-hub]Meta Quest Developer Hub[/url] or [url=https://developers.meta.com/horizon/documentation/native/xrsim-intro/]download it directly[/url].\n"
 		"  Extract the files into a folder on your computer.\n"
 		"  Enter the full path to the [code]meta_openxr_simulator.json[/code] file within that directory.\n"
 		"[/ol]\n\n"


### PR DESCRIPTION
Fixes #24 

Change the XR Sim doc link to one that better directs users to the correct downloads.

Edit: I've also updated the link in the XR Sim setup tool dialog, and added a couple things to `.gitignore`.