### PR TITLE
Create new dictionary when updating openxr runtime paths

### DIFF
--- a/toolkit/src/main/cpp/editor/meta_xr_simulator_dialog.cpp
+++ b/toolkit/src/main/cpp/editor/meta_xr_simulator_dialog.cpp
@@ -156,8 +156,10 @@ void MetaXRSimulatorDialog::_set_simulator_path(const String &p_path) {
 		runtime_paths = editor_settings->get_setting(OPENXR_RUNTIME_PATHS_SETTING);
 	}
 
-	runtime_paths[META_SIMULATOR_RUNTIME_NAME] = p_path;
-	editor_settings->set_setting(OPENXR_RUNTIME_PATHS_SETTING, runtime_paths);
+	Dictionary new_runtime_paths;
+	new_runtime_paths.merge(runtime_paths);
+	new_runtime_paths[META_SIMULATOR_RUNTIME_NAME] = p_path;
+	editor_settings->set_setting(OPENXR_RUNTIME_PATHS_SETTING, new_runtime_paths);
 }
 
 MetaXRSimulatorDialog::MetaXRSimulatorDialog() {


### PR DESCRIPTION
Fixes #23

In order to properly flag the editor setting as changed, a new dictionary must be created and passed to `set_setting()`.